### PR TITLE
Bugfix race condition bahnhof liste und weitere

### DIFF
--- a/Plugin Gleisbelegung/src/com/gleisbelegung/Fenster.java
+++ b/Plugin Gleisbelegung/src/com/gleisbelegung/Fenster.java
@@ -450,7 +450,7 @@ public class Fenster{
             gleise.getChildren().add(cbBahnhof[counterBhf]);
             counterBhf++;
             //dann alle Gleise in die mittlere und rechte Spalte schreiben
-            for (int i = 0; i < bahnhof.getBahnsteige().size(); i++) {
+            for (int i = 0; i < bahnhof.getAnzahlBahnsteige(); i++) {
                 cbGleis[counterGleis] = new CheckBox(bahnhof.getBahnsteig(i).getName());
                 cbGleis[counterGleis].setTranslateX(tempX);
                 cbGleis[counterGleis].setTranslateY(tempY);

--- a/Plugin Gleisbelegung/src/com/gleisbelegung/Gleisbelegung.java
+++ b/Plugin Gleisbelegung/src/com/gleisbelegung/Gleisbelegung.java
@@ -21,6 +21,8 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Date;
+import java.util.SortedMap;
+import java.util.TreeMap;
 
 public class Gleisbelegung {
     private GridPane gp;                                //Das ist die Tabelle, die alles enthält.                       (Vereinfacht einige Sachen, könnte/sollte irgendwann entfernt werden
@@ -143,7 +145,7 @@ public class Gleisbelegung {
         }
 
         for(Bahnhof bahnhof : stellwerk.getBahnhoefe()){
-            for (int i = 0; i < bahnhof.getBahnsteige().size(); i++) {
+            for (int i = 0; i < bahnhof.getAnzahlBahnsteige(); i++) {
                 LabelContainer lc = new LabelContainer(i,null);
                 lc.updateLabel(bahnhof.getBahnsteig(i).getName(), true);
                 lc.getAussehen().textFarbe = "#fff";
@@ -182,11 +184,11 @@ public class Gleisbelegung {
         labelIndexCounter = Einstellungen.vorschau;
 
         for(Bahnhof b : stellwerk.getBahnhoefe()){
-            for(LabelContainer lc : b.getBahnsteige().get(b.getBahnsteige().size()-1).getSpalte()){
+            for(LabelContainer lc : b.getLastBahnsteig().getSpalte()){
                 lc.setLetzterBahnsteig(true);
 
-                b.getBahnsteige().get(b.getBahnsteige().size()-1).getGleisLabel().setLetzterBahnsteig(true);
-                Label l = b.getBahnsteige().get(b.getBahnsteige().size()-1).getGleisLabel().getLabel();
+                b.getLastBahnsteig().getGleisLabel().setLetzterBahnsteig(true);
+                Label l = b.getLastBahnsteig().getGleisLabel().getLabel();
                 l.setStyle(l.getStyle() + " -fx-border-width: 0 5 5 0;");
             }
         }
@@ -239,7 +241,7 @@ public class Gleisbelegung {
                 for (int i = 0; i < z.getFahrplan().size(); i++) {
                     if (z.getFahrplan(i) != null && z.getFahrplan(i).getVorgaenger() == null) {
                         for (Bahnhof b : stellwerk.getBahnhoefe()) {
-                            for (int j = 0; j < b.getBahnsteige().size(); j++) {
+                            for (int j = 0; j < b.getAnzahlBahnsteige(); j++) {
                                 Bahnsteig g = b.getBahnsteig(j);
                                 if (g != null && z.getFahrplan(i) != null && z.getFahrplan(i).getBahnsteig().getName().equals(g.getName())) {
                                     if (z.getFahrplan(i).getFlaggedTrain() != null) {
@@ -433,11 +435,12 @@ public class Gleisbelegung {
     public void sortiereGleise(){
         Platform.runLater(() -> {
             sortierteGleise = new ArrayList<>();
+            SortedMap<Integer, Bahnsteig> gleisMap = new TreeMap<>();
             for(Bahnhof bahnhof : stellwerk.getBahnhoefe()){
-                sortierteGleise.addAll(bahnhof.getBahnsteige());
+                gleisMap.putAll(bahnhof.getBahnsteigOrderMap());
             }
 
-            sortierteGleise.sort(Comparator.comparing(Bahnsteig::getOrderId));
+            sortierteGleise.addAll(gleisMap.values());
 
             gpPlatform.getChildren().clear();
             gp.getChildren().clear();
@@ -473,7 +476,7 @@ public class Gleisbelegung {
 
         gpBahnhof.getChildren().clear();
         for(Bahnhof b : stellwerk.getBahnhoefe()){
-            b.getBahnhofTeile().clear();
+            b.clearBahnhofTeile();
         }
 
         for(Bahnsteig bahnsteig : sortierteGleise){

--- a/Plugin Gleisbelegung/src/com/gleisbelegung/Stellwerksuebersicht.java
+++ b/Plugin Gleisbelegung/src/com/gleisbelegung/Stellwerksuebersicht.java
@@ -15,8 +15,11 @@ import javafx.scene.text.Text;
 
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.Date;
+import java.util.List;
+import java.util.Set;
 
 import javafx.scene.shape.Line;
 
@@ -40,7 +43,7 @@ public class Stellwerksuebersicht {
         gc.setFont(Font.font(Einstellungen.schriftgroesse));*/
 
         for(Bahnhof b : stellwerk.getBahnhoefe()){
-            if(b.getBahnhofVerbindungen() != null) b.getBahnhofVerbindungen().clear();
+            if(b.getBahnhofVerbindungen() != null) b.clearBahnhofVerbindungen();
 
             String text = "";
             if(b.getName().equals("")) text = stellwerk.getStellwerksname();
@@ -179,10 +182,13 @@ public class Stellwerksuebersicht {
     }
 
     private void updateLinie(Bahnhof b){
-        ArrayList<Bahnhof> verbindungsBahnhoefe = b.getVerbindungsBahnhoefe();
+        Set<Bahnhof> verbindungsBahnhoefe = b.getVerbindungsBahnhoefe();
 
         for(Bahnhof vb : verbindungsBahnhoefe){
             Line linie = b.getLinie(vb);
+            if (linie == null) {
+              continue;
+            }
             Vec2d linienPosB1 = new Vec2d();
             Vec2d linienPosB2 = new Vec2d();
 

--- a/Plugin Gleisbelegung/src/com/gleisbelegung/Stellwerksuebersicht.java
+++ b/Plugin Gleisbelegung/src/com/gleisbelegung/Stellwerksuebersicht.java
@@ -271,7 +271,11 @@ public class Stellwerksuebersicht {
 
                     if(!content.getChildren().contains(l)){
                         Platform.runLater(() -> {
-                            content.getChildren().add(l);
+                          synchronized(content) {
+                            if(!content.getChildren().contains(l)) {
+                              content.getChildren().add(l);
+                            }
+                          }
                         });
                     }
                 } else if(content.getChildren().contains(z.getStellwerksUebersichtLabel())){

--- a/Plugin Gleisbelegung/src/com/gleisbelegung/lib/Stellwerk.java
+++ b/Plugin Gleisbelegung/src/com/gleisbelegung/lib/Stellwerk.java
@@ -64,11 +64,11 @@ public class Stellwerk {
             }
             bahnhofsName[i] = bahnsteige[i].replaceAll("\\P{L}+", "");
             if(letzterBahnhofsName.equals(bahnhofsName[i]) && bahnhoefe.size() > 0){
-                bahnhoefe.get(bahnhoefe.size()-1).getBahnsteige().add(new Bahnsteig(bahnhoefe.get(bahnhoefe.size()-1), bahnsteigsName, i));
+                bahnhoefe.get(bahnhoefe.size()-1).addBahnsteig(new Bahnsteig(bahnhoefe.get(bahnhoefe.size()-1), bahnsteigsName, i));
             } else {
                 letzterBahnhofsName = bahnhofsName[i];
                 bahnhoefe.add(new Bahnhof(bahnhoefe.size(), letzterBahnhofsName));
-                bahnhoefe.get(bahnhoefe.size()-1).getBahnsteige().add(new Bahnsteig(bahnhoefe.get(bahnhoefe.size()-1), bahnsteigsName, i));
+                bahnhoefe.get(bahnhoefe.size()-1).addBahnsteig(new Bahnsteig(bahnhoefe.get(bahnhoefe.size()-1), bahnsteigsName, i));
             }
         }
     }
@@ -115,7 +115,7 @@ public class Stellwerk {
     }
     public List<Zug> getZuege() {
     	synchronized(zuege) {
-    		return Collections.unmodifiableList(zuege);
+    		return Collections.unmodifiableList(new ArrayList<Zug>(zuege));
     	}
     }
     public void addZug(Zug zug) {

--- a/Plugin Gleisbelegung/src/com/gleisbelegung/lib/Verbindung.java
+++ b/Plugin Gleisbelegung/src/com/gleisbelegung/lib/Verbindung.java
@@ -387,8 +387,9 @@ public class Verbindung {
 
     private Bahnsteig sucheBahnsteig(String name) {
         for (Bahnhof bahnhof : stellwerk.getBahnhoefe()) {
-            for (Bahnsteig bahnsteig : bahnhof.getBahnsteige()) {
-                if (bahnsteig.getName().equals(name)) return bahnsteig;
+            Bahnsteig bst = bahnhof.getBahnsteigByName(name);
+            if (bst != null) {
+              return bst;
             }
         }
         return null;

--- a/Plugin Gleisbelegung/src/com/gleisbelegung/lib/data/Bahnhof.java
+++ b/Plugin Gleisbelegung/src/com/gleisbelegung/lib/data/Bahnhof.java
@@ -14,223 +14,339 @@ import javafx.stage.Stage;
 
 import javafx.scene.shape.Line;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.TreeMap;
 
 public class Bahnhof {
-    private int id;
-    private String name;
-    private String alternativName = "";
-    private ArrayList<Bahnsteig> bahnsteige;
-    private ArrayList<BahnhofTeil> bahnhofTeile;
-    private ArrayList<BahnhofVerbindung> bahnhofVerbindungen;
-    private boolean sichtbar;
-    private Vec2d pos;
+  /**
+   * Vebindung zwischen Bahnhof.this and BahnhofVerbindung.ziel
+   *
+   */
+  private class BahnhofVerbindung {
+    private double laenge; // dead variable
+    private Line linie;
+    private Vec2d linienPos;
+    private Bahnhof ziel;
 
-    public Bahnhof(int id, String name){
-        this.id = id;
-        this.name = name;
-        this.bahnsteige = new ArrayList<>();
-        this.bahnhofTeile = new ArrayList<>();
-        this.bahnhofVerbindungen = new ArrayList<>();
-        pos = new Vec2d(30, id*40 + 40);
+    public BahnhofVerbindung(Bahnhof bahnhof, double laenge, Line linie, Vec2d linienPos) {
+      this.laenge = laenge;
+      this.linie = linie;
+      this.linienPos = linienPos;
+      ziel = bahnhof;
     }
 
-    public int getId(){
-        return id;
-    }
-    public String getName() {
-        return name;
-    }
-    public ArrayList<Bahnsteig> getBahnsteige() {
-        return bahnsteige;
-    }
-    public Bahnsteig getBahnsteig(int index){
-        return bahnsteige.get(index);
-    }
-    public int getAnzahlBahnsteige(){
-        return bahnsteige.size();
+    public void setLinienPos(Vec2d linienPos) {
+      this.linienPos = linienPos;
     }
 
-    public boolean isSichtbar() {
-        for (Bahnsteig b : bahnsteige) {
-            if (!b.isSichtbar())
-                return false;
-
-        }
-        return true;
+    public Vec2d getLinienPos() {
+      return linienPos;
     }
 
-    public void setSichtbar(boolean sichtbar) {
-        for (Bahnsteig b : bahnsteige)
-            b.setSichtbar(sichtbar);
+    public Bahnhof getStartBahnhof() {
+      return Bahnhof.this;
     }
 
-    public ArrayList<BahnhofTeil> getBahnhofTeile() {
-        return bahnhofTeile;
+    public Bahnhof getZielBahnhof() {
+      return ziel;
     }
-    public void addBahnhofLabel(LabelContainer bahnhofLabel, ArrayList<Bahnsteig> bahnsteige) {
-        BahnhofTeil bt = new BahnhofTeil(bahnhofLabel, bahnsteige);
-        bahnhofTeile.add(bt);
+  }
 
-        bahnhofLabel.getLabel().setOnMouseClicked(e -> {
-            if(e.getButton() == MouseButton.PRIMARY){
-                hervorheben(bt);
-                System.out.println(bt.bahnsteige.size());
-            } else if(e.getButton() == MouseButton.SECONDARY) {
-                einstellungen(bt);
-            }
-        });
+  private class BahnhofTeil implements Iterable<Bahnsteig> {
+    private LabelContainer bahnhofsLabel;
+    private List<Bahnsteig> bahnsteige;
+
+    public BahnhofTeil(LabelContainer bahnhofsLabel, List<Bahnsteig> bahnsteige) {
+      this.bahnhofsLabel = bahnhofsLabel;
+      this.bahnsteige = bahnsteige;
+
     }
 
-    public String getAlternativName() { return alternativName; }
-
-    private void einstellungen(BahnhofTeil bt){
-        Einstellungen.fenster.gleisbelegung.zeigeOrderIds();
-        Stage stage = new Stage();
-
-        Label name = new Label("Name:");
-        name.setStyle("-fx-text-fill: white;");
-        name.setFont(Font.font(Einstellungen.schriftgroesse));
-        name.setTranslateY(25);
-        name.setTranslateX(25);
-
-        TextField tname = new TextField(alternativName);
-        tname.setFont(Font.font(Einstellungen.schriftgroesse-3));
-        tname.setTranslateX(25);
-        tname.setTranslateY(60);
-
-        Label l = new Label("Reihenfolge festlegen:");
-        l.setStyle("-fx-text-fill: white;");
-        l.setFont(Font.font(Einstellungen.schriftgroesse));
-        l.setTranslateX(25);
-        l.setTranslateY(95);
-
-        TextField tf = new TextField(String.valueOf(bahnsteige.get(0).getOrderId()+1));
-        tf.setFont(Font.font(Einstellungen.schriftgroesse-3));
-        tf.setTranslateX(25);
-        tf.setTranslateY(130);
-
-        Button b = new Button("Speichern");
-        b.setFont(Font.font(Einstellungen.schriftgroesse));
-        b.setTranslateX(25);
-        b.setTranslateY(190);
-        b.setOnAction(e -> {
-            int order = Integer.parseInt(tf.getText())-1;
-            for(Bahnsteig ba : bt.bahnsteige){
-                ba.setOrderId(order);
-                alternativName = tname.getText();
-            }
-
-            stage.close();
-            Einstellungen.fenster.gleisbelegung.versteckeOrderIds();
-            Einstellungen.fenster.gleisbelegung.sortiereGleise();
-            Einstellungen.fenster.stellwerksuebersicht.aktualisiereBahnhofsNamen();
-        });
-
-        Pane p = new Pane(name, tname,l,tf,b);
-        p.setStyle("-fx-background-color: #303030;");
-        p.setMinSize(500,200);
-        p.setMaxSize(500, 200);
-
-        Scene scene = new Scene(p, 300,250);
-
-        stage.setScene(scene);
-        stage.show();
-        stage.setAlwaysOnTop(true);
-
-        stage.setOnCloseRequest(e -> {
-            Einstellungen.fenster.gleisbelegung.versteckeOrderIds();
-        });
+    void hervorheben() {
+      for (Bahnsteig b : bahnsteige) {
+        b.hebeHervor();
+      }
     }
 
-    private void hervorheben(BahnhofTeil bt){
-        for(Bahnsteig b: bt.bahnsteige){
-            b.hebeHervor();
-        }
+    public int getBahnsteigSize() {
+      return bahnsteige.size();
     }
 
-    @Override
-    public String toString() {
-        return "Bahnhof{" +
-                "id=" + id +
-                ", name='" + name + '\'' +
-                ", bahnsteige=" + bahnsteige +
-                '}';
+    public Iterator<Bahnsteig> iterator() {
+      return bahnsteige.iterator();
+    }
+  }
+
+  private int id;
+  private String name;
+  private String alternativName = "";
+  private Map<String, Bahnsteig> bahnsteige = new HashMap<>();
+  private List<Bahnsteig> bahnsteigListe = new ArrayList<>();
+  private List<BahnhofTeil> bahnhofTeile = new ArrayList<>();
+  private Map<Integer, BahnhofVerbindung> bahnhofVerbindungen = new HashMap<>();
+  private boolean sichtbar;
+  private Vec2d pos;
+  private Bahnsteig lastBahnsteig;
+
+  public Bahnhof(int id, String name) {
+    this.id = id;
+    this.name = name;
+    pos = new Vec2d(30, id * 40 + 40);
+  }
+
+  private BahnhofVerbindung getVerbindung(Bahnhof bahnhof) {
+    synchronized (bahnhofVerbindungen) {
+      return bahnhofVerbindungen.get(Integer.valueOf(bahnhof.id));
+    }
+  }
+
+  public int getId() {
+    return id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public Collection<Bahnsteig> getBahnsteige() {
+    synchronized (bahnsteigListe) {
+      return Collections.unmodifiableList(new ArrayList<>(bahnsteigListe));
+    }
+  }
+
+  public Bahnsteig getBahnsteig(int index) {
+    synchronized (bahnsteigListe) {
+      return bahnsteigListe.get(index);
+    }
+  }
+
+  public int getAnzahlBahnsteige() {
+    synchronized (bahnsteige) {
+      return bahnsteige.size();
+    }
+  }
+
+  public boolean isSichtbar() {
+    synchronized (bahnsteige) {
+      for (Bahnsteig b : bahnsteige.values()) {
+        if (!b.isSichtbar())
+          return false;
+
+      }
+    }
+    return true;
+  }
+
+  public void setSichtbar(boolean sichtbar) {
+    synchronized (bahnsteige) {
+      for (Bahnsteig b : bahnsteige.values())
+        b.setSichtbar(sichtbar);
+    }
+  }
+
+  public List<BahnhofTeil> getBahnhofTeile() {
+    synchronized (bahnhofTeile) {
+      return Collections.unmodifiableList(bahnhofTeile);
+    }
+  }
+
+  public void addBahnhofLabel(LabelContainer bahnhofLabel, List<Bahnsteig> bahnsteige) {
+    BahnhofTeil bt = new BahnhofTeil(bahnhofLabel, bahnsteige);
+    synchronized (bahnhofTeile) {
+      bahnhofTeile.add(bt);
     }
 
-    public Vec2d getPos() {
-        return pos;
+    bahnhofLabel.getLabel().setOnMouseClicked(e -> {
+      if (e.getButton() == MouseButton.PRIMARY) {
+        bt.hervorheben();
+        System.out.println(bt.getBahnsteigSize());
+      } else if (e.getButton() == MouseButton.SECONDARY) {
+        einstellungen(bt);
+      }
+    });
+  }
+
+  public String getAlternativName() {
+    return alternativName;
+  }
+
+  private void einstellungen(BahnhofTeil bt) {
+    Einstellungen.fenster.gleisbelegung.zeigeOrderIds();
+    Stage stage = new Stage();
+
+    Label name = new Label("Name:");
+    name.setStyle("-fx-text-fill: white;");
+    name.setFont(Font.font(Einstellungen.schriftgroesse));
+    name.setTranslateY(25);
+    name.setTranslateX(25);
+
+    TextField tname = new TextField(alternativName);
+    tname.setFont(Font.font(Einstellungen.schriftgroesse - 3));
+    tname.setTranslateX(25);
+    tname.setTranslateY(60);
+
+    Label l = new Label("Reihenfolge festlegen:");
+    l.setStyle("-fx-text-fill: white;");
+    l.setFont(Font.font(Einstellungen.schriftgroesse));
+    l.setTranslateX(25);
+    l.setTranslateY(95);
+
+    TextField tf = new TextField(String.valueOf(bahnsteige.get(0).getOrderId() + 1));
+    tf.setFont(Font.font(Einstellungen.schriftgroesse - 3));
+    tf.setTranslateX(25);
+    tf.setTranslateY(130);
+
+    Button b = new Button("Speichern");
+    b.setFont(Font.font(Einstellungen.schriftgroesse));
+    b.setTranslateX(25);
+    b.setTranslateY(190);
+    b.setOnAction(e -> {
+      int order = Integer.parseInt(tf.getText()) - 1;
+      for (Bahnsteig ba : bt) {
+        ba.setOrderId(order);
+        alternativName = tname.getText();
+      }
+
+      stage.close();
+      Einstellungen.fenster.gleisbelegung.versteckeOrderIds();
+      Einstellungen.fenster.gleisbelegung.sortiereGleise();
+      Einstellungen.fenster.stellwerksuebersicht.aktualisiereBahnhofsNamen();
+    });
+
+    Pane p = new Pane(name, tname, l, tf, b);
+    p.setStyle("-fx-background-color: #303030;");
+    p.setMinSize(500, 200);
+    p.setMaxSize(500, 200);
+
+    Scene scene = new Scene(p, 300, 250);
+
+    stage.setScene(scene);
+    stage.show();
+    stage.setAlwaysOnTop(true);
+
+    stage.setOnCloseRequest(e -> {
+      Einstellungen.fenster.gleisbelegung.versteckeOrderIds();
+    });
+  }
+
+  @Override
+  public String toString() {
+    return "Bahnhof{" + "id=" + id + ", name='" + name + '\'' + ", bahnsteige=" + bahnsteige + '}';
+  }
+
+  public Vec2d getPos() {
+    return pos;
+  }
+
+  public void setPos(Vec2d pos) {
+    this.pos = pos;
+  }
+
+  public Collection<BahnhofVerbindung> getBahnhofVerbindungen() {
+    synchronized (bahnhofVerbindungen) {
+      return Collections.unmodifiableCollection(bahnhofVerbindungen.values());
     }
-    public void setPos(Vec2d pos) {
-        this.pos = pos;
+  }
+
+  public void addBahnhofVerbindung(Bahnhof bahnhof, double laenge, Line linie, Vec2d linienPos) {
+    BahnhofVerbindung verbindung = new BahnhofVerbindung(bahnhof, laenge, linie, linienPos);
+    synchronized (bahnhofVerbindungen) {
+      bahnhofVerbindungen.put(Integer.valueOf(bahnhof.id), verbindung);
+    }
+  }
+
+  public Line getLinie(Bahnhof bahnhof) {
+    BahnhofVerbindung bv = getVerbindung(bahnhof);
+
+    if (bv == null) {
+      return null;
     }
 
-    public ArrayList<BahnhofVerbindung> getBahnhofVerbindungen() {
-        return bahnhofVerbindungen;
-    }
-    public void addBahnhofVerbindung(Bahnhof bahnhof, double laenge, Line linie, Vec2d linienPos){
-        bahnhofVerbindungen.add(new BahnhofVerbindung(bahnhof, laenge, linie, linienPos));
-    }
-    public double getVerbindungsLaenge(Bahnhof bahnhof){
-        for(BahnhofVerbindung bv : bahnhofVerbindungen){
-            if(bv.bahnhof.getId() == bahnhof.getId()){
-                return bv.laenge;
-            }
-        }
-        return -1;
-    }
-    public Line getLinie(Bahnhof bahnhof){
-        for(BahnhofVerbindung bv : bahnhofVerbindungen){
-            if(bv.bahnhof.getId() == bahnhof.getId()){
-                return bv.linie;
-            }
-        }
-        return null;
-    }
-    public ArrayList<Bahnhof> getVerbindungsBahnhoefe(){
-        ArrayList<Bahnhof> bahnhoefe = new ArrayList<>();
-        for(BahnhofVerbindung bv : bahnhofVerbindungen){
-            bahnhoefe.add(bv.bahnhof);
-        }
-        return bahnhoefe;
-    }
-    public Vec2d getLinienPos(Bahnhof bahnhof){
-        for(BahnhofVerbindung bv : bahnhofVerbindungen){
-            if(bv.bahnhof.getId() == bahnhof.getId()){
-                return bv.linienPos;
-            }
-        }
-        return null;
-    }
-    public void setLinienPos(Bahnhof bahnhof, Vec2d linienPos){
-        for(BahnhofVerbindung bv : bahnhofVerbindungen){
-            if(bv.bahnhof.getId() == bahnhof.getId()){
-                bv.linienPos = linienPos;
-                break;
-            }
-        }
-    }
-}
+    return bv.linie;
+  }
 
-class BahnhofTeil{
-    LabelContainer bahnhofsLabel;
-    ArrayList<Bahnsteig> bahnsteige;
-
-    public BahnhofTeil(LabelContainer bahnhofsLabel, ArrayList<Bahnsteig> bahnsteige){
-        this.bahnhofsLabel = bahnhofsLabel;
-        this.bahnsteige = bahnsteige;
+  public Set<Bahnhof> getVerbindungsBahnhoefe() {
+    Collection<BahnhofVerbindung> bvs = getBahnhofVerbindungen();
+    Set<Bahnhof> bahnhofSet = new HashSet<>();
+    for (BahnhofVerbindung bv : bvs) {
+      bahnhofSet.add(bv.getZielBahnhof());
     }
-}
 
-class BahnhofVerbindung{
-    Bahnhof bahnhof;
-    double laenge;
-    Line linie;
-    Vec2d linienPos;
+    return bahnhofSet;
+  }
 
-    public BahnhofVerbindung(Bahnhof bahnhof, double laenge, Line linie, Vec2d linienPos){
-        this.bahnhof = bahnhof;
-        this.laenge = laenge;
-        this.linie = linie;
-        this.linienPos = linienPos;
+  public Vec2d getLinienPos(Bahnhof bahnhof) {
+    BahnhofVerbindung bv = getVerbindung(bahnhof);
+    if (bv == null) {
+      return null;
     }
+
+    return bv.getLinienPos();
+  }
+
+  public boolean setLinienPos(Bahnhof bahnhof, Vec2d linienPos) {
+    BahnhofVerbindung bv = getVerbindung(bahnhof);
+    if (bv == null) {
+      return false;
+    }
+
+    bv.setLinienPos(linienPos);
+
+    return true;
+  }
+
+  public Bahnsteig getBahnsteigByName(String name) {
+    synchronized (bahnsteige) {
+      return bahnsteige.get(name);
+    }
+  }
+
+  public void addBahnsteig(Bahnsteig bahnsteig) {
+    synchronized (bahnsteige) {
+      this.bahnsteige.put(bahnsteig.getName(), bahnsteig);
+      this.lastBahnsteig = bahnsteig;
+    }
+    synchronized (bahnsteigListe) {
+      bahnsteigListe.add(bahnsteig);
+    }
+  }
+
+  public Bahnsteig getLastBahnsteig() {
+    synchronized (bahnsteige) {
+      return lastBahnsteig;
+    }
+  }
+
+  public void clearBahnhofVerbindungen() {
+    synchronized (bahnhofVerbindungen) {
+      this.bahnhofVerbindungen.clear();
+    }
+
+  }
+
+  public SortedMap<Integer, Bahnsteig> getBahnsteigOrderMap() {
+    SortedMap<Integer, Bahnsteig> bahnsteigMap = new TreeMap<>();
+    synchronized (bahnsteige) {
+      for (Bahnsteig bst : bahnsteige.values()) {
+        bahnsteigMap.put(Integer.valueOf(bst.getOrderId()), bst);
+      }
+    }
+
+    return bahnsteigMap;
+  }
+
+  public void clearBahnhofTeile() {
+    synchronized (bahnhofTeile) {
+      bahnhofTeile.clear();
+    }
+
+  }
 }


### PR DESCRIPTION
Thread-Safe Umbau zur Behebung von #89.

Die for-Schleifen um einen Eintrag zu finden, habe ich durch gezielte Lookups in Maps ersetzt, um Performance-Einbussen wegen der neuen synchronized-Blöcke zu reduzieren.

Beim Testen aufgefallen, dass #93 noch immer auftreten kann, daher Kopie der Liste angelegt, um Problem endgültig zu beheben. 

Weiteres Problem beim Testen aufgrund Nebenläufigkeit von Threads gefunden und behoben:
```
 Exception in thread "JavaFX Application Thread" java.lang.IllegalArgumentException: Children: duplicate children added: parent = Pane@75c81f9d
            at javafx.scene.Parent$2.onProposedChange(Parent.java:454)
            at com.sun.javafx.collections.VetoableListDecorator.add(VetoableListDecorator.java:206)
            at com.gleisbelegung.Stellwerksuebersicht.lambda$8(Stellwerksuebersicht.java:274)
            at com.sun.javafx.application.PlatformImpl.lambda$null$172(PlatformImpl.java:295)
            at java.security.AccessController.doPrivileged(Native Method)
            at com.sun.javafx.application.PlatformImpl.lambda$runLater$173(PlatformImpl.java:294)
            at com.sun.glass.ui.InvokeLaterDispatcher$Future.run(InvokeLaterDispatcher.java:95)
            at com.sun.glass.ui.gtk.GtkApplication._runLoop(Native Method)
            at com.sun.glass.ui.gtk.GtkApplication.lambda$null$48(GtkApplication.java:139)
            at java.lang.Thread.run(Thread.java:748)
```
