### PR TITLE
Fix#108

### DIFF
--- a/Plugin Gleisbelegung/src/com/gleisbelegung/Fenster.java
+++ b/Plugin Gleisbelegung/src/com/gleisbelegung/Fenster.java
@@ -313,6 +313,10 @@ public class Fenster{
         stellwerksuebersicht.update();
     }
 
+    public Stellwerk getStellwerk() {
+      return this.stellwerk;
+    }
+
     private void updateUi(){
         Einstellungen.maximiert = primaryStage.isMaximized();
         stageHeight = primaryStage.getHeight();

--- a/Plugin Gleisbelegung/src/com/gleisbelegung/Fenster.java
+++ b/Plugin Gleisbelegung/src/com/gleisbelegung/Fenster.java
@@ -16,28 +16,16 @@ import com.gleisbelegung.lib.data.FahrplanHalt;
 import com.gleisbelegung.lib.data.Zug;
 import javafx.application.Platform;
 import javafx.event.ActionEvent;
-import javafx.geometry.Insets;
-import javafx.geometry.Orientation;
-import javafx.geometry.Pos;
 import javafx.scene.Scene;
 import javafx.scene.control.*;
-import javafx.scene.input.MouseButton;
 import javafx.scene.layout.BorderPane;
-import javafx.scene.layout.GridPane;
 import javafx.scene.layout.Pane;
-import javafx.scene.media.AudioClip;
-import javafx.scene.media.Media;
-import javafx.scene.media.MediaPlayer;
 import javafx.scene.text.Font;
-import javafx.scene.text.FontPosture;
 import javafx.stage.Stage;
 
-import java.io.File;
-import java.io.FileWriter;
 import java.io.PrintWriter;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.Date;
 
 public class Fenster{
@@ -215,9 +203,9 @@ public class Fenster{
                     if(z.getFahrplan(i).getFlaggedTrain() != null){
                         Zug flagged = z.getFahrplan(i).getFlaggedTrain();
 
-                        long lAnkunft = z.getFahrplan(i).getAnkuft() + z.getVerspaetung()*1000*60;
-                        long lAbfahrt = flagged.getFahrplan(0).getAbfahrt() + flagged.getVerspaetung()*1000*60;
-                        if(flagged.getVerspaetung() > 3 && (lAbfahrt-lAnkunft)/1000/60 > 3){
+                        long lAnkunft = z.getFahrplan(i).getAnkuft() + z.getVerspaetungInMinuten()*1000*60;
+                        long lAbfahrt = flagged.getFahrplan(0).getAbfahrt() + flagged.getVerspaetungInMinuten()*1000*60;
+                        if(flagged.getVerspaetungInMinuten() > 3 && (lAbfahrt-lAnkunft)/1000/60 > 3){
                             lAbfahrt = lAnkunft + 4*1000*60;
                         }
 
@@ -238,13 +226,13 @@ public class Fenster{
 
                         informations.getChildren().add(l);
                     } else{
-                        long lAnkunft = z.getFahrplan(i).getAnkuft() + z.getVerspaetung()*1000*60;
-                        long lAbfahrt = z.getFahrplan(i).getAbfahrt() + z.getVerspaetung()*1000*60;
-                        if(z.getVerspaetung() > 3 && (lAbfahrt-lAnkunft)/1000/60 > 3){
+                        long lAnkunft = z.getFahrplan(i).getAnkuft() + z.getVerspaetungInMinuten()*1000*60;
+                        long lAbfahrt = z.getFahrplan(i).getAbfahrt() + z.getVerspaetungInMinuten()*1000*60;
+                        if(z.getVerspaetungInMinuten() > 3 && (lAbfahrt-lAnkunft)/1000/60 > 3){
                             lAbfahrt = lAnkunft + 4*1000*60;
                         }
                         if (z.getFahrplan(i).getVorgaenger() != null)
-                            lAnkunft = z.getFahrplan(i).getVorgaenger().getAnkuft() + z.getFahrplan(i).getVorgaenger().getZ().getVerspaetung() * 1000 * 60;
+                            lAnkunft = z.getFahrplan(i).getVorgaenger().getAnkuft() + z.getFahrplan(i).getVorgaenger().getZug().getVerspaetungInMinuten() * 1000 * 60;
                         Date anunft = new Date(lAnkunft);
                         Date abfahrt = new Date(lAbfahrt);
                         SimpleDateFormat ft = new SimpleDateFormat("HH:mm");
@@ -570,11 +558,11 @@ public class Fenster{
             }
         }
 
-        for (LabelContainer lc : gleisbelegung.getLabelTime()) {
+        /*for (LabelContainer lc : gleisbelegung.getLabelTime()) {
             lc.getLabel().setFont(Font.font(Einstellungen.schriftgroesse - 5));
             lc.getLabel().setMaxWidth(Einstellungen.spaltenbreite);
             lc.getLabel().setMinWidth(Einstellungen.spaltenbreite);
-        }
+        }*/
 
         for (Bahnhof b : stellwerk.getBahnhoefe()) {
             for(Bahnsteig ba : b.getBahnsteige()){
@@ -587,7 +575,7 @@ public class Fenster{
                     ba.getGleisLabel().getLabel().setMinWidth(0);
                 }
 
-                for(LabelContainer lc : ba.getSpalte()){
+                /*for(LabelContainer lc : ba.getSpalte()){
                     lc.getLabel().setFont(Font.font(Einstellungen.schriftgroesse - 5));
                     if(ba.isSichtbar()){
                         lc.getLabel().setMaxWidth(Einstellungen.spaltenbreite);
@@ -596,7 +584,7 @@ public class Fenster{
                         lc.getLabel().setMaxWidth(0);
                         lc.getLabel().setMinWidth(0);
                     }
-                }
+                }*/
             }
         }
 

--- a/Plugin Gleisbelegung/src/com/gleisbelegung/Fenster.java
+++ b/Plugin Gleisbelegung/src/com/gleisbelegung/Fenster.java
@@ -79,7 +79,7 @@ public class Fenster{
         einstellungen.setFont(Font.font(Einstellungen.schriftgroesse - 2));
         einstellungen.setOnAction(e -> { try{ settings(); }catch(Exception ex) { ex.printStackTrace(); } });
 
-        sichtwechsel = new Button("Stellwerksübersicht (BETA)");
+        sichtwechsel = new Button("Stellwerksübersicht");
         sichtwechsel.setFont(Font.font(Einstellungen.schriftgroesse - 2));
 
         refresh.setText("Neustart");
@@ -132,7 +132,7 @@ public class Fenster{
                 bp.setCenter(stellwerksuebersicht.getContent());
             } else if(Einstellungen.sicht == 2){
                 Einstellungen.sicht = 1;
-                sichtwechsel.setText("Stellwerksübersicht (BETA)");
+                sichtwechsel.setText("Stellwerksübersicht");
                 bp.setCenter(gleisbelegung.getContent());
             }
         });

--- a/Plugin Gleisbelegung/src/com/gleisbelegung/Fenster.java
+++ b/Plugin Gleisbelegung/src/com/gleisbelegung/Fenster.java
@@ -450,7 +450,7 @@ public class Fenster{
             gleise.getChildren().add(cbBahnhof[counterBhf]);
             counterBhf++;
             //dann alle Gleise in die mittlere und rechte Spalte schreiben
-            for (int i = 0; i < bahnhof.getBahnsteige().size(); i++) {
+            for (int i = 0; i < bahnhof.getAnzahlBahnsteige(); i++) {
                 cbGleis[counterGleis] = new CheckBox(bahnhof.getBahnsteig(i).getName());
                 cbGleis[counterGleis].setTranslateX(tempX);
                 cbGleis[counterGleis].setTranslateY(tempY);

--- a/Plugin Gleisbelegung/src/com/gleisbelegung/Gleisbelegung.java
+++ b/Plugin Gleisbelegung/src/com/gleisbelegung/Gleisbelegung.java
@@ -15,12 +15,8 @@ import javafx.scene.control.ScrollPane;
 import javafx.scene.layout.GridPane;
 import javafx.scene.layout.Pane;
 import javafx.scene.text.Font;
-import javafx.scene.text.FontPosture;
 
-import java.text.SimpleDateFormat;
 import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.Date;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
@@ -243,6 +239,15 @@ public class Gleisbelegung {
         }
     }
 
+    public void aktualisiereTabelle(){
+        //TODO Das soll eigentlich nur vorläufig sein
+        Platform.runLater(() -> {
+            gp.getChildren().clear();
+            gpTime.getChildren().clear();
+            zeichneTabelle();
+        });
+    }
+
     public void update(){
         boolean wasUpdate = false;
         for (Zug z : stellwerk.getZuege()) {
@@ -251,88 +256,17 @@ public class Gleisbelegung {
                     z.setNewTrain(false);
                     fh.setNeedUpdate(false);
 
-                    timeTable.addTrain(z);
                     wasUpdate = true;
-                }
-            }
-        }
+                    System.out.println("UPDATE " + z);
 
-        if(wasUpdate){
-            //TODO Das soll eigentlich nur vorläufig sein
-            Platform.runLater(() -> {
-                gp.getChildren().clear();
-                gpTime.getChildren().clear();
-                zeichneTabelle();
-            });
-        }
-        /*for (Zug z : stellwerk.getZuege()) {
-            try {
-                if (z.isNeedUpdate() && z.getFahrplan(0) != null && z.getFahrplan(0).getVorgaenger() != null) {
-                    z.getFahrplan(0).getVorgaenger().getZug().setNeedUpdate(true);
+                    if(z.isNewTrain()) timeTable.addZug(z);
+                    else timeTable.updateFahrplanhalt(fh);
                 }
-            } catch (Exception e) {
-                System.out.println("Fehler koennen passieren :(");
-                e.printStackTrace();
             }
         }
-        for (Zug z : stellwerk.getZuege()) {
-            try {
-                if(z.isNewTrain()){
-                    timeTable.addTrain(z);
-                }
-
-                if (z.isNeedUpdate()) {
-                    //drawTrain(z);
-                    timeTable.updateTrain(z);
-                    z.setNeedUpdate(false);
-                    z.setNewTrain(false);
-                }
-            } catch (Exception e) {
-                System.out.println("Fehler koennen passieren :(");
-                e.printStackTrace();
-            }
-        }*/
 
         if(gp.getChildren().size() == 0) zeichneTabelle();
-        else aktualisiereTabelle();
-    }
-
-    public void aktualisiereTabelle(){
-
-    }
-
-    private void updateSomeTrains(long time){
-        /*for(Zug z : stellwerk.getZuege()){
-            try{
-                if (z.getFahrplan() != null && z.getFahrplan(0) != null) {
-                    for (int i = 0; i < z.getFahrplan().size(); i++) {
-                        if (z.getFahrplan(i) != null && z.getFahrplan(i).getFlaggedTrain() != null) {
-                            Zug eFlag = z.getFahrplan(i).getFlaggedTrain();
-
-                            if (z.getFahrplan() != null && z.getFahrplan(i) != null && eFlag != null && eFlag.getFahrplan() != null && eFlag.getFahrplan(0) != null) {
-                                long ankunft = z.getFahrplan(i).getAnkuft() + z.getVerspaetungInMinuten() * 1000 * 60;
-                                long abfahrt = eFlag.getFahrplan(0).getAbfahrt() + eFlag.getVerspaetungInMinuten() * 1000 * 60;
-
-                                if (ankunft <= time && abfahrt >= time) {
-                                    z.setNeedUpdate(true);
-                                }
-                            }
-                        } else if (z.getFahrplan() != null && z.getFahrplan(i) != null) {
-                            long ankunft = z.getFahrplan(i).getAnkuft() + z.getVerspaetungInMinuten() * 1000 * 60;
-                            long abfahrt = z.getFahrplan(i).getAbfahrt() + z.getVerspaetungInMinuten() * 1000 * 60;
-
-                            if (ankunft <= time && abfahrt >= time) {
-                                z.setNeedUpdate(true);
-                            }
-
-                        }
-                    }
-                }
-            } catch(Exception e){
-                e.printStackTrace();
-                System.out.println("ZUG: " + z.getZugName() + ": Darstellungsfehler!");
-            }
-        }*/
+        else if(wasUpdate) aktualisiereTabelle();
     }
 
     public void sortiereGleise(){

--- a/Plugin Gleisbelegung/src/com/gleisbelegung/Gleisbelegung.java
+++ b/Plugin Gleisbelegung/src/com/gleisbelegung/Gleisbelegung.java
@@ -200,7 +200,8 @@ public class Gleisbelegung {
 
         int rowCounter = 0;
 
-        for(TimeTableRow ttr : timeTable.rows){
+        for(Iterator<TimeTable.TimeTableRow> iterRow = timeTable.rowIterator(); iterRow.hasNext(); ){
+        	TimeTable.TimeTableRow ttr = iterRow.next();
             LabelContainer lc = new LabelContainer(rowCounter, null);
 
             final int temp = rowCounter;
@@ -211,13 +212,14 @@ public class Gleisbelegung {
 
             int colCounter = 0;
 
-            for(TimeTableData ttd : ttr.fields){
-                LabelContainer lcTemp = new LabelContainer(rowCounter, ttd.col.bahnsteig);
-                lcTemp.updateLabel("", ttd.row.time);
+            for(Iterator<TimeTable.TimeTableData> iterData = ttr.dataIterator(); iterData.hasNext(); ){
+            	TimeTable.TimeTableData ttd = iterData.next();
+                LabelContainer lcTemp = new LabelContainer(rowCounter, ttd.getCol().getBahnsteig());
+                lcTemp.updateLabel("", ttd.getRow().time);
 
-                if(ttd.zuege.size() > 0){
+                if(ttd.getZuege().size() > 0){
                     try{
-                        for(FahrplanHalt fh : ttd.zuege){
+                        for(FahrplanHalt fh : ttd.getZuege()){
                             lcTemp.addTrain(fh.getZug());
                         }
                     } catch (Exception ex){

--- a/Plugin Gleisbelegung/src/com/gleisbelegung/Gleisbelegung.java
+++ b/Plugin Gleisbelegung/src/com/gleisbelegung/Gleisbelegung.java
@@ -337,8 +337,10 @@ public class Gleisbelegung {
 
             for(Bahnhof bahnhof : stellwerk.getBahnhoefe()){
                 for(Bahnsteig bahnsteig : bahnhof.getBahnsteige()){
-                    gp.getChildren().remove(bahnsteig.getSpalte().get(0).getLabel());
-                    bahnsteig.getSpalte().remove(0);
+                    if(gp != null && gp.getChildren() != null && bahnsteig != null && bahnsteig.getSpalte() != null && bahnsteig.getSpalte().get(0) != null && bahnsteig.getSpalte().get(0).getLabel() != null){
+                        gp.getChildren().remove(bahnsteig.getSpalte().get(0).getLabel());
+                        bahnsteig.getSpalte().remove(0);
+                    }
                 }
             }
         });

--- a/Plugin Gleisbelegung/src/com/gleisbelegung/Gleisbelegung.java
+++ b/Plugin Gleisbelegung/src/com/gleisbelegung/Gleisbelegung.java
@@ -16,10 +16,7 @@ import javafx.scene.layout.GridPane;
 import javafx.scene.layout.Pane;
 import javafx.scene.text.Font;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.SortedSet;
-import java.util.TreeSet;
+import java.util.*;
 
 public class Gleisbelegung {
     private GridPane gp;                                //Das ist die Tabelle, die alles enthält.                       (Vereinfacht einige Sachen, könnte/sollte irgendwann entfernt werden
@@ -219,9 +216,15 @@ public class Gleisbelegung {
                 lcTemp.updateLabel("", ttd.row.time);
 
                 if(ttd.zuege.size() > 0){
-                    for(FahrplanHalt fh : ttd.zuege){
-                        lcTemp.addTrain(fh.getZug());
+                    try{
+                        for(FahrplanHalt fh : ttd.zuege){
+                            lcTemp.addTrain(fh.getZug());
+                        }
+                    } catch (Exception ex){
+                        ex.printStackTrace();
+                        System.out.println("SCHEISSE");
                     }
+
                 }
 
                 final int tempCol = colCounter;
@@ -253,15 +256,22 @@ public class Gleisbelegung {
     public void update(){
         boolean wasUpdate = false;
         for (Zug z : stellwerk.getZuege()) {
-            for(FahrplanHalt fh : z.getFahrplan()){
-                if(z.isNewTrain() || fh.isNeedUpdate()){
-                    wasUpdate = true;
+            if(z.getZugName().equals("LT 84355")){
+                System.out.println("zug");
+            }
 
-                    if(z.isNewTrain()) timeTable.addZug(z);
-                    else timeTable.updateFahrplanhalt(fh);
-
-                    z.setNewTrain(false);
-                    fh.setNeedUpdate(false);
+            if(z.isNewTrain()) {
+                timeTable.addZug(z);
+                wasUpdate = true;
+            } else if(z.isSchwerwiegendesUpdate()) {
+                timeTable.updateZug(z);
+                wasUpdate = true;
+            } else {
+                for(FahrplanHalt fh : z.getFahrplan()){
+                    if(fh.isNeedUpdate()){
+                        wasUpdate = true;
+                        timeTable.updateFahrplanhalt(fh);
+                    }
                 }
             }
         }

--- a/Plugin Gleisbelegung/src/com/gleisbelegung/Gleisbelegung.java
+++ b/Plugin Gleisbelegung/src/com/gleisbelegung/Gleisbelegung.java
@@ -21,6 +21,8 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Date;
+import java.util.SortedMap;
+import java.util.TreeMap;
 
 public class Gleisbelegung {
     private GridPane gp;                                //Das ist die Tabelle, die alles enthält.                       (Vereinfacht einige Sachen, könnte/sollte irgendwann entfernt werden
@@ -143,7 +145,7 @@ public class Gleisbelegung {
         }
 
         for(Bahnhof bahnhof : stellwerk.getBahnhoefe()){
-            for (int i = 0; i < bahnhof.getBahnsteige().size(); i++) {
+            for (int i = 0; i < bahnhof.getAnzahlBahnsteige(); i++) {
                 LabelContainer lc = new LabelContainer(i,null);
                 lc.updateLabel(bahnhof.getBahnsteig(i).getName(), true);
                 lc.getAussehen().textFarbe = "#fff";
@@ -182,11 +184,11 @@ public class Gleisbelegung {
         labelIndexCounter = Einstellungen.vorschau;
 
         for(Bahnhof b : stellwerk.getBahnhoefe()){
-            for(LabelContainer lc : b.getBahnsteige().get(b.getBahnsteige().size()-1).getSpalte()){
+            for(LabelContainer lc : b.getLastBahnsteig().getSpalte()){
                 lc.setLetzterBahnsteig(true);
 
-                b.getBahnsteige().get(b.getBahnsteige().size()-1).getGleisLabel().setLetzterBahnsteig(true);
-                Label l = b.getBahnsteige().get(b.getBahnsteige().size()-1).getGleisLabel().getLabel();
+                b.getLastBahnsteig().getGleisLabel().setLetzterBahnsteig(true);
+                Label l = b.getLastBahnsteig().getGleisLabel().getLabel();
                 l.setStyle(l.getStyle() + " -fx-border-width: 0 5 5 0;");
             }
         }
@@ -239,7 +241,7 @@ public class Gleisbelegung {
                 for (int i = 0; i < z.getFahrplan().size(); i++) {
                     if (z.getFahrplan(i) != null && z.getFahrplan(i).getVorgaenger() == null) {
                         for (Bahnhof b : stellwerk.getBahnhoefe()) {
-                            for (int j = 0; j < b.getBahnsteige().size(); j++) {
+                            for (int j = 0; j < b.getAnzahlBahnsteige(); j++) {
                                 Bahnsteig g = b.getBahnsteig(j);
                                 if (g != null && z.getFahrplan(i) != null && z.getFahrplan(i).getBahnsteig().getName().equals(g.getName())) {
                                     if (z.getFahrplan(i).getFlaggedTrain() != null) {
@@ -433,11 +435,12 @@ public class Gleisbelegung {
     public void sortiereGleise(){
         Platform.runLater(() -> {
             sortierteGleise = new ArrayList<>();
+            SortedMap<Integer, Bahnsteig> gleisMap = new TreeMap<>();
             for(Bahnhof bahnhof : stellwerk.getBahnhoefe()){
-                sortierteGleise.addAll(bahnhof.getBahnsteige());
+                gleisMap.putAll(bahnhof.getBahnsteigOrderMap());
             }
 
-            sortierteGleise.sort(Comparator.comparing(Bahnsteig::getOrderId));
+            sortierteGleise.addAll(gleisMap.values());
 
             gpPlatform.getChildren().clear();
             gp.getChildren().clear();
@@ -473,7 +476,7 @@ public class Gleisbelegung {
 
         gpBahnhof.getChildren().clear();
         for(Bahnhof b : stellwerk.getBahnhoefe()){
-            b.getBahnhofTeile().clear();
+            b.clearBahnhofTeile();
         }
 
         for(Bahnsteig bahnsteig : sortierteGleise){

--- a/Plugin Gleisbelegung/src/com/gleisbelegung/Gleisbelegung.java
+++ b/Plugin Gleisbelegung/src/com/gleisbelegung/Gleisbelegung.java
@@ -536,7 +536,7 @@ public class Gleisbelegung {
         }
 
         LabelContainer lc = new LabelContainer(-1, null);
-        if(!letzterBahnsteig.getBahnhof().getAlternativName().equals("")) {
+        if(letzterBahnsteig != null && letzterBahnsteig.getBahnhof() != null && letzterBahnsteig.getBahnhof().getAlternativName() != null && !letzterBahnsteig.getBahnhof().getAlternativName().equals("")) {
             lc.getLabel().setText(letzterBahnsteig.getBahnhof().getAlternativName() + (!letzterBahnsteig.getBahnhof().getName().equals("") ? " (" + letzterBahnsteig.getBahnhof().getName() + ")" : ""));
         }
         else if(!letzterBahnsteig.getBahnhof().getName().equals("")) lc.getLabel().setText(letzterBahnsteig.getBahnhof().getName());

--- a/Plugin Gleisbelegung/src/com/gleisbelegung/Gleisbelegung.java
+++ b/Plugin Gleisbelegung/src/com/gleisbelegung/Gleisbelegung.java
@@ -17,8 +17,6 @@ import javafx.scene.layout.Pane;
 import javafx.scene.text.Font;
 
 import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.Date;
 import java.util.List;
 import java.util.SortedSet;
 import java.util.TreeSet;
@@ -35,7 +33,6 @@ public class Gleisbelegung {
     private ScrollBar scrollBarWidth;                   //Scroll-Balken um die Tabelle bewegen zu können
     private ScrollBar scrollBarHeight;                  //Scroll-Balken um die Tabelle bewegen zu können
     private Label firstLabel;                           //neues Label oben links mit Bahnhofs-Namen
-    private int labelIndexCounter;                      //Zählt die Textfelder auf der y-Achse mit um eine Identifikation zu ermöglichen
     private List<Bahnsteig> sortierteGleise = new ArrayList<>();
 
     private Pane content;
@@ -222,8 +219,8 @@ public class Gleisbelegung {
                 lcTemp.updateLabel("", ttd.row.time);
 
                 if(ttd.zuege.size() > 0){
-                    for(Zug z : ttd.zuege){
-                        lcTemp.addTrain(z);
+                    for(FahrplanHalt fh : ttd.zuege){
+                        lcTemp.addTrain(fh.getZug());
                     }
                 }
 
@@ -243,6 +240,8 @@ public class Gleisbelegung {
     }
 
     public void aktualisiereTabelle(){
+        timeTable.entferneVergangenheit();
+
         //TODO Das soll eigentlich nur vorläufig sein
         Platform.runLater(() -> {
             gp.getChildren().clear();
@@ -256,14 +255,13 @@ public class Gleisbelegung {
         for (Zug z : stellwerk.getZuege()) {
             for(FahrplanHalt fh : z.getFahrplan()){
                 if(z.isNewTrain() || fh.isNeedUpdate()){
-                    z.setNewTrain(false);
-                    fh.setNeedUpdate(false);
-
                     wasUpdate = true;
-                    System.out.println("UPDATE " + z);
 
                     if(z.isNewTrain()) timeTable.addZug(z);
                     else timeTable.updateFahrplanhalt(fh);
+
+                    z.setNewTrain(false);
+                    fh.setNeedUpdate(false);
                 }
             }
         }

--- a/Plugin Gleisbelegung/src/com/gleisbelegung/LabelContainer.java
+++ b/Plugin Gleisbelegung/src/com/gleisbelegung/LabelContainer.java
@@ -31,6 +31,7 @@ public class LabelContainer extends Plugin {
     private boolean letzterBahnsteig;
     private Aussehen aussehen;
     private boolean hervorhebungDurchGleis;
+    private boolean timeLabel;
 
     public LabelContainer(int labelIndex, Bahnsteig bahnsteig){
         this.bahnsteig = bahnsteig;
@@ -38,6 +39,7 @@ public class LabelContainer extends Plugin {
         trains = new ArrayList<>();
         aussehen = new Aussehen();
         hervorhebungDurchGleis = false;
+        timeLabel = false;
 
         l = new Label();
         l.setFont(Font.font(Einstellungen.schriftgroesse-5));
@@ -113,79 +115,87 @@ public class LabelContainer extends Plugin {
     }
 
     public void updateLabel(){
-        if(trains.size() == 0){
-            Platform.runLater(() -> {
-                l.setText("");
-                l.setTooltip(null);
-                if(hervorhebungDurchGleis){
-                    aussehen.hintergrundFarbe = "#181818";
-                    aussehen.textFarbe = "#fff";
-                    prepareBorder();
-                } else if (labelIndex % 2 == 0) {
-                    aussehen.hintergrundFarbe = "transparent";
-                    aussehen.textFarbe = "#fff";
-                    prepareBorder();
-                } else {
-                    aussehen.hintergrundFarbe = "#292929";
-                    aussehen.textFarbe = "#fff";
-                    prepareBorder();
-                }
-
-                if(letzterBahnsteig){
-                    aussehen.raender.setze(0, 5 ,1, 0);
-                }
-
-                l.setStyle(aussehen.toCSSStyle());
-            });
-        } else if(trains.size() == 1){
-            Zug train = trains.get(0);
-            Platform.runLater(() -> {
-                l.setText(train.getZugName() + train.getVerspaetungToString());
-                l.setTooltip(new Tooltip(train.getZugName() + train.getVerspaetungToString()));
-                aussehen.hintergrundFarbe = prepareTrainStyle(train.getZugName());
+        if(timeLabel){
+            prepareBorder();
+            if (labelIndex % 2 != 0) {
+                aussehen.hintergrundFarbe = "#292929";
                 aussehen.textFarbe = "#fff";
-                prepareBorder();
-
-                if(letzterBahnsteig){
-                    aussehen.raender.setze(0, 5 ,1, 0);
-                }
-
-                l.setStyle(aussehen.toCSSStyle());
-            });
-        } else if (trains.size() == 2 && trains.get(1).getFahrplan(0).getVorgaenger() != null) {  //TODO sinn dieser Alternative, identisch zu oben?
-            Zug train = trains.get(1);
-            Platform.runLater(() -> {
-                l.setText(train.getZugName() + train.getVerspaetungToString());
-                l.setTooltip(new Tooltip(train.getZugName() + train.getVerspaetungToString()));
-                aussehen.hintergrundFarbe = prepareTrainStyle(train.getZugName());
-                aussehen.textFarbe = "#fff";
-                prepareBorder();
-                l.setStyle(aussehen.toCSSStyle());
-            });
+            }
         } else {
-            Platform.runLater(() -> {
-                if(trains != null && trains.size() > 0){
-                    String text = "";
-
-                    for (Zug z : trains) {
-                        text += z.getZugName() + z.getVerspaetungToString() + ", "; //TODO kann laut Log null werden
+            if(trains.size() == 0){
+                Platform.runLater(() -> {
+                    l.setText("");
+                    l.setTooltip(null);
+                    if(hervorhebungDurchGleis){
+                        aussehen.hintergrundFarbe = "#181818";
+                        aussehen.textFarbe = "#fff";
+                        prepareBorder();
+                    } else if (labelIndex % 2 == 0) {
+                        aussehen.hintergrundFarbe = "transparent";
+                        aussehen.textFarbe = "#fff";
+                        prepareBorder();
+                    } else {
+                        aussehen.hintergrundFarbe = "#292929";
+                        aussehen.textFarbe = "#fff";
+                        prepareBorder();
                     }
-                    text = text.substring(0, text.length() - 2);
 
-                    final String temp = text;
-                    l.setText(temp);
-                    l.setTooltip(new Tooltip(temp));
-                    aussehen.hintergrundFarbe = "red";
+                    if(letzterBahnsteig){
+                        aussehen.raender.setze(0, 5 ,1, 0);
+                    }
+
+                    l.setStyle(aussehen.toCSSStyle());
+                });
+            } else if(trains.size() == 1){
+                Zug train = trains.get(0);
+                Platform.runLater(() -> {
+                    l.setText(train.getZugName() + train.getVerspaetungToString());
+                    l.setTooltip(new Tooltip(train.getZugName() + train.getVerspaetungToString()));
+                    aussehen.hintergrundFarbe = prepareTrainStyle(train.getZugName());
                     aussehen.textFarbe = "#fff";
                     prepareBorder();
 
                     if(letzterBahnsteig){
-                        aussehen.raender.setze(0, 5, 1, 0);
+                        aussehen.raender.setze(0, 5 ,1, 0);
                     }
 
                     l.setStyle(aussehen.toCSSStyle());
-                }
-            });
+                });
+            } else if (trains.size() == 2 && trains.get(1).getFahrplan(0).getVorgaenger() != null) {  //TODO sinn dieser Alternative, identisch zu oben?
+                Zug train = trains.get(1);
+                Platform.runLater(() -> {
+                    l.setText(train.getZugName() + train.getVerspaetungToString());
+                    l.setTooltip(new Tooltip(train.getZugName() + train.getVerspaetungToString()));
+                    aussehen.hintergrundFarbe = prepareTrainStyle(train.getZugName());
+                    aussehen.textFarbe = "#fff";
+                    prepareBorder();
+                    l.setStyle(aussehen.toCSSStyle());
+                });
+            } else {
+                Platform.runLater(() -> {
+                    if(trains != null && trains.size() > 0){
+                        String text = "";
+
+                        for (Zug z : trains) {
+                            text += z.getZugName() + z.getVerspaetungToString() + ", "; //TODO kann laut Log null werden
+                        }
+                        text = text.substring(0, text.length() - 2);
+
+                        final String temp = text;
+                        l.setText(temp);
+                        l.setTooltip(new Tooltip(temp));
+                        aussehen.hintergrundFarbe = "red";
+                        aussehen.textFarbe = "#fff";
+                        prepareBorder();
+
+                        if(letzterBahnsteig){
+                            aussehen.raender.setze(0, 5, 1, 0);
+                        }
+
+                        l.setStyle(aussehen.toCSSStyle());
+                    }
+                });
+            }
         }
     }
     public void updateLabel(String text, boolean isBahnsteig){
@@ -249,6 +259,10 @@ public class LabelContainer extends Plugin {
         Date dNow = new Date(time);
         SimpleDateFormat ft = new SimpleDateFormat("HH:mm");
         String localTime = ft.format(dNow);
+
+        if(timeLabel){
+            l.setText(localTime);
+        }
 
         if(localTime.endsWith("00")){
             aussehen.raender.farbeRechts = "#505050";
@@ -343,15 +357,15 @@ public class LabelContainer extends Plugin {
             Fenster.informations.getChildren().addAll(trainName, vonBis);
 
             for(int i = 0; i < z.getFahrplan().size(); i++){
-                long lAnkunft = z.getFahrplan(i).getAnkuft() + z.getVerspaetung()*1000*60;
-                long lAbfahrt = z.getFahrplan(i).getAbfahrt() + z.getVerspaetung()*1000*60;
-                if(z.getVerspaetung() > 3 && (lAbfahrt-lAnkunft)/1000/60 > 3){
+                long lAnkunft = z.getFahrplan(i).getAnkuft() + z.getVerspaetungInMinuten()*1000*60;
+                long lAbfahrt = z.getFahrplan(i).getAbfahrt() + z.getVerspaetungInMinuten()*1000*60;
+                if(z.getVerspaetungInMinuten() > 3 && (lAbfahrt-lAnkunft)/1000/60 > 3){
                     lAbfahrt = lAnkunft + 4*1000*60;
                 }
                 if (z.getFahrplan(i).getFlaggedTrain() != null && z.getFahrplan(i).getFlaggedTrain().getFahrplan(0) != null) {
-                    lAbfahrt = z.getFahrplan(i).getFlaggedTrain().getFahrplan(0).getAbfahrt() + z.getFahrplan(i).getFlaggedTrain().getVerspaetung() * 1000 * 60;
-                } else if (z.getFahrplan(i).getVorgaenger() != null && z.getFahrplan(i).getVorgaenger().getZ() != null) {
-                    lAnkunft = z.getFahrplan(i).getVorgaenger().getAnkuft() + z.getFahrplan(i).getVorgaenger().getZ().getVerspaetung() * 1000 * 60;
+                    lAbfahrt = z.getFahrplan(i).getFlaggedTrain().getFahrplan(0).getAbfahrt() + z.getFahrplan(i).getFlaggedTrain().getVerspaetungInMinuten() * 1000 * 60;
+                } else if (z.getFahrplan(i).getVorgaenger() != null && z.getFahrplan(i).getVorgaenger().getZug() != null) {
+                    lAnkunft = z.getFahrplan(i).getVorgaenger().getAnkuft() + z.getFahrplan(i).getVorgaenger().getZug().getVerspaetungInMinuten() * 1000 * 60;
                 }
 
                 String durchfahrt = "";
@@ -432,6 +446,21 @@ public class LabelContainer extends Plugin {
 
     public Aussehen getAussehen() {
         return aussehen;
+    }
+
+    public boolean isTimeLabel() {
+        return timeLabel;
+    }
+    public void setTimeLabel(boolean timeLabel, long time) {
+        this.timeLabel = timeLabel;
+        this.time = time;
+
+        updateLabel();
+
+        aussehen.raender.rechts = 5;
+        aussehen.textFarbe = "#fff";
+
+        l.setStyle(aussehen.toCSSStyle());
     }
 }
 

--- a/Plugin Gleisbelegung/src/com/gleisbelegung/Plugin.java
+++ b/Plugin Gleisbelegung/src/com/gleisbelegung/Plugin.java
@@ -39,7 +39,7 @@ public class Plugin extends Application implements Runnable{
     private Fenster f;
 
     private String host = "192.168.1.25";                   //Die Ip des Rechnsers, auf welchem die Sim läuft           (Wird bei einer Änderung beim Pluginstart aktualisiert)
-    private int version = 16;                                //Aktualle Version des Plugins
+    private int version = 17;                                //Aktualle Version des Plugins
 
     private Stellwerk stellwerk;
     public static Einstellungen einstellungen;

--- a/Plugin Gleisbelegung/src/com/gleisbelegung/Plugin.java
+++ b/Plugin Gleisbelegung/src/com/gleisbelegung/Plugin.java
@@ -13,12 +13,15 @@ Hier befindet sich auch die Hauptschleife des Plugins.
 import com.gleisbelegung.lib.Stellwerk;
 import javafx.application.Application;
 import javafx.application.Platform;
+import javafx.event.EventHandler;
 import javafx.geometry.Rectangle2D;
 import javafx.scene.Scene;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
 import javafx.scene.control.TextField;
 import javafx.scene.image.Image;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.Pane;
 import javafx.scene.layout.StackPane;
 import javafx.scene.text.Font;
@@ -76,16 +79,7 @@ public class Plugin extends Application implements Runnable{
             lHost.applyCss();
             lHost.layout();
 
-            tfHost.setText("Warten...");
-            tfHost.setStyle("-fx-text-fill: black;");
-            tfHost.setFont(Font.font(Einstellungen.schriftgroesse));
-            tfHost.setTranslateX(120);
-            tfHost.setTranslateY(80);
-            tfHost.setMinWidth(150);
-            tfHost.setMaxWidth(150);
-            tfHost.applyCss();
-            tfHost.layout();
-            tfHost.setDisable(true);
+
             //p.widthProperty().addListener((observable, oldValue, newValue) -> tfHost.setTranslateX(newValue.doubleValue()/2 - 75));
 
             Button btLoad = new Button("Verbinden");
@@ -97,6 +91,22 @@ public class Plugin extends Application implements Runnable{
             btLoad.applyCss();
             btLoad.layout();
             btLoad.setDisable(true);
+
+            tfHost.setText("Warten...");
+            tfHost.setStyle("-fx-text-fill: black;");
+            tfHost.setFont(Font.font(Einstellungen.schriftgroesse));
+            tfHost.setTranslateX(120);
+            tfHost.setTranslateY(80);
+            tfHost.setMinWidth(150);
+            tfHost.setMaxWidth(150);
+            tfHost.applyCss();
+            tfHost.layout();
+            tfHost.setDisable(true);
+            tfHost.setOnKeyPressed(ke -> {
+                if (ke.getCode().equals(KeyCode.ENTER)){
+                    btLoad.fire();
+                }
+            });
 
             firstSP.getChildren().addAll(lHint, lHost, tfHost, btLoad);
             firstSP.applyCss();
@@ -190,6 +200,9 @@ public class Plugin extends Application implements Runnable{
 
                     btLoad.setOnAction(e -> {
                         host = tfHost.getText();
+                        tfHost.setDisable(true);
+                        btLoad.setDisable(true);
+                        btLoad.setText("Laden...");
                         Platform.runLater(() -> startLoading(tempSocket));
                     });
                 });
@@ -311,8 +324,13 @@ public class Plugin extends Application implements Runnable{
 
                 update = false;
                 refresh.setDisable(true);
-                refresh.setText("Warten...");
+                Platform.runLater(() -> {
+                    refresh.setText("Warten...");
+                });
                 Thread.sleep(2000);
+                Platform.runLater(() -> {
+                    refresh.setText("Laden...");
+                });
                 startLoading(null);
             } catch (InterruptedException e) {
                 e.printStackTrace();

--- a/Plugin Gleisbelegung/src/com/gleisbelegung/Plugin.java
+++ b/Plugin Gleisbelegung/src/com/gleisbelegung/Plugin.java
@@ -311,6 +311,7 @@ public class Plugin extends Application implements Runnable{
 
                 update = false;
                 refresh.setDisable(true);
+                refresh.setText("Warten...");
                 Thread.sleep(2000);
                 startLoading(null);
             } catch (InterruptedException e) {

--- a/Plugin Gleisbelegung/src/com/gleisbelegung/Stellwerksuebersicht.java
+++ b/Plugin Gleisbelegung/src/com/gleisbelegung/Stellwerksuebersicht.java
@@ -15,8 +15,11 @@ import javafx.scene.text.Text;
 
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.Date;
+import java.util.List;
+import java.util.Set;
 
 import javafx.scene.shape.Line;
 
@@ -40,7 +43,7 @@ public class Stellwerksuebersicht {
         gc.setFont(Font.font(Einstellungen.schriftgroesse));*/
 
         for(Bahnhof b : stellwerk.getBahnhoefe()){
-            if(b.getBahnhofVerbindungen() != null) b.getBahnhofVerbindungen().clear();
+            if(b.getBahnhofVerbindungen() != null) b.clearBahnhofVerbindungen();
 
             String text = "";
             if(b.getName().equals("")) text = stellwerk.getStellwerksname();
@@ -179,10 +182,13 @@ public class Stellwerksuebersicht {
     }
 
     private void updateLinie(Bahnhof b){
-        ArrayList<Bahnhof> verbindungsBahnhoefe = b.getVerbindungsBahnhoefe();
+        Set<Bahnhof> verbindungsBahnhoefe = b.getVerbindungsBahnhoefe();
 
         for(Bahnhof vb : verbindungsBahnhoefe){
             Line linie = b.getLinie(vb);
+            if (linie == null) {
+              continue;
+            }
             Vec2d linienPosB1 = new Vec2d();
             Vec2d linienPosB2 = new Vec2d();
 
@@ -265,7 +271,11 @@ public class Stellwerksuebersicht {
 
                     if(!content.getChildren().contains(l)){
                         Platform.runLater(() -> {
-                            content.getChildren().add(l);
+                          synchronized(content) {
+                            if(!content.getChildren().contains(l)) {
+                              content.getChildren().add(l);
+                            }
+                          }
                         });
                     }
                 } else if(content.getChildren().contains(z.getStellwerksUebersichtLabel())){

--- a/Plugin Gleisbelegung/src/com/gleisbelegung/Stellwerksuebersicht.java
+++ b/Plugin Gleisbelegung/src/com/gleisbelegung/Stellwerksuebersicht.java
@@ -249,8 +249,8 @@ public class Stellwerksuebersicht {
                 Bahnhof b1 = z.getFahrplan(0).getBahnsteig().getBahnhof();
                 Bahnhof b2 = z.getFahrplan(1).getBahnsteig().getBahnhof();
 
-                long abfahrtsZeit = (z.getFahrplan(0).getAbfahrt() + z.getVerspaetung() * 1000 * 60 - stellwerk.getSpielzeit())/1000;
-                long ankunftsZeit = (z.getFahrplan(1).getAnkuft() + z.getVerspaetung() * 1000 * 60 - stellwerk.getSpielzeit())/1000;
+                long abfahrtsZeit = (z.getFahrplan(0).getAbfahrt() + z.getVerspaetungInMinuten() * 1000 * 60 - stellwerk.getSpielzeit())/1000;
+                long ankunftsZeit = (z.getFahrplan(1).getAnkuft() + z.getVerspaetungInMinuten() * 1000 * 60 - stellwerk.getSpielzeit())/1000;
 
                 if(abfahrtsZeit < 0 && ankunftsZeit > 0){
                     double aufenthalt = (double) ((z.getFahrplan(1).getAnkuft()/1000) - (z.getFahrplan(0).getAbfahrt()/1000));
@@ -298,7 +298,7 @@ public class Stellwerksuebersicht {
         for(Zug z : stellwerk.getZuege()){
             if(z.getFahrplan() != null){ //z != null braucht nicht überprüft werden, da die durch die foreach bereits ausgeschlossen werden
                 for(FahrplanHalt fh : z.getFahrplan()){
-                    if(fh.getBahnsteig().getBahnhof().getId() == b.getId() && fh.getAbfahrt() + fh.getZ().getVerspaetung() * 1000 * 60 > stellwerk.getSpielzeit()){
+                    if(fh.getBahnsteig().getBahnhof().getId() == b.getId() && fh.getAbfahrt() + fh.getZug().getVerspaetungInMinuten() * 1000 * 60 > stellwerk.getSpielzeit()){
                         abfahrten.add(fh);
                     }
                 }
@@ -317,10 +317,10 @@ public class Stellwerksuebersicht {
             gezeichneteBahnhofsInformationen.add(l);
 
             for(int i = 0; i < abfahrten.size() && i < 5; i++){
-                Date dNow = new Date(abfahrten.get(i).getAbfahrt() + abfahrten.get(i).getZ().getVerspaetung() * 1000 * 60);
+                Date dNow = new Date(abfahrten.get(i).getAbfahrt() + abfahrten.get(i).getZug().getVerspaetungInMinuten() * 1000 * 60);
                 SimpleDateFormat ft = new SimpleDateFormat("HH:mm");
 
-                l = new Label(ft.format(dNow) + " " + abfahrten.get(i).getZ().getZugName() + abfahrten.get(i).getZ().getVerspaetungToString());
+                l = new Label(ft.format(dNow) + " " + abfahrten.get(i).getZug().getZugName() + abfahrten.get(i).getZug().getVerspaetungToString());
                 l.setStyle("-fx-text-fill: #fff;");
                 l.setFont(Font.font(Einstellungen.schriftgroesse));
                 l.setTranslateX(b.getPos().x);

--- a/Plugin Gleisbelegung/src/com/gleisbelegung/Stellwerksuebersicht.java
+++ b/Plugin Gleisbelegung/src/com/gleisbelegung/Stellwerksuebersicht.java
@@ -112,8 +112,14 @@ public class Stellwerksuebersicht {
         for(Bahnhof b : stellwerk.getBahnhoefe()){
             String text;
 
-            if(b.getName().equals("")) text = stellwerk.getStellwerksname();
-            else text = b.getName();
+            if(b.getAlternativName().equals("")){
+                if(b.getName().equals("")) text = stellwerk.getStellwerksname();
+                else text = b.getName();
+            } else {
+                if(b.getName().equals("")) text = b.getAlternativName() + " (" + stellwerk.getStellwerksname() + ")";
+                else text = b.getAlternativName() + " (" + b.getName() + ")";
+            }
+
 
             Text temp = new Text(text);
             temp.setFont(Font.font(Einstellungen.schriftgroesse));
@@ -332,5 +338,28 @@ public class Stellwerksuebersicht {
 
     public Pane getContent() {
         return content;
+    }
+
+    public void aktualisiereBahnhofsNamen(){
+        int counter = 0;
+        for(Label l : bahnhofsLabel){
+            Bahnhof b = stellwerk.getBahnhoefe().get(counter);
+            String text = "";
+
+            if(b.getAlternativName().equals("")){
+                if(b.getName().equals("")) text = stellwerk.getStellwerksname();
+                else text = b.getName();
+            } else {
+                if(b.getName().equals("")) text = b.getAlternativName() + " (" + stellwerk.getStellwerksname() + ")";
+                else text = b.getAlternativName() + " (" + b.getName() + ")";
+            }
+
+            final String tempText = text;
+            Platform.runLater(() -> {
+                l.setText(tempText);
+            });
+
+            counter++;
+        }
     }
 }

--- a/Plugin Gleisbelegung/src/com/gleisbelegung/Stellwerksuebersicht.java
+++ b/Plugin Gleisbelegung/src/com/gleisbelegung/Stellwerksuebersicht.java
@@ -8,6 +8,7 @@ import com.sun.javafx.geom.Vec2d;
 import javafx.application.Platform;
 import javafx.geometry.Pos;
 import javafx.scene.control.Label;
+import javafx.scene.input.MouseButton;
 import javafx.scene.layout.Pane;
 import javafx.scene.paint.Paint;
 import javafx.scene.text.Font;
@@ -72,6 +73,11 @@ public class Stellwerksuebersicht {
                 b.getPos().y = b.getPos().y + counter * 50;
             }
             l.setOnMouseEntered(mouse -> zeigeBahnhofsInformationen(b));
+            l.setOnMouseClicked(mouse -> {
+                if (mouse.getButton() == MouseButton.SECONDARY) {
+                    b.einstellungen(b.getBahnhofTeile(0));
+                }
+            });
             l.setOnMouseExited(mouse -> entferneBahnhofsInformationen());
             bahnhofsLabel.add(l);
 

--- a/Plugin Gleisbelegung/src/com/gleisbelegung/Stellwerksuebersicht.java
+++ b/Plugin Gleisbelegung/src/com/gleisbelegung/Stellwerksuebersicht.java
@@ -274,9 +274,11 @@ public class Stellwerksuebersicht {
     private void zeigeBahnhofsInformationen(Bahnhof b){
         ArrayList<FahrplanHalt> abfahrten = new ArrayList<>();
         for(Zug z : stellwerk.getZuege()){
-            for(FahrplanHalt fh : z.getFahrplan()){
-                if(fh.getBahnsteig().getBahnhof().getId() == b.getId() && fh.getAbfahrt() + fh.getZ().getVerspaetung() * 1000 * 60 > stellwerk.getSpielzeit()){
-                    abfahrten.add(fh);
+            if(z.getFahrplan() != null){ //z != null braucht nicht überprüft werden, da die durch die foreach bereits ausgeschlossen werden
+                for(FahrplanHalt fh : z.getFahrplan()){
+                    if(fh.getBahnsteig().getBahnhof().getId() == b.getId() && fh.getAbfahrt() + fh.getZ().getVerspaetung() * 1000 * 60 > stellwerk.getSpielzeit()){
+                        abfahrten.add(fh);
+                    }
                 }
             }
         }

--- a/Plugin Gleisbelegung/src/com/gleisbelegung/TimeTable.java
+++ b/Plugin Gleisbelegung/src/com/gleisbelegung/TimeTable.java
@@ -6,47 +6,72 @@ import com.gleisbelegung.lib.data.FahrplanHalt;
 import com.gleisbelegung.lib.data.Zug;
 
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 
 public class TimeTable {
 
 	class TimeTableColumn{
-	    Bahnsteig bahnsteig;
-	    List<TimeTableRow> rows;
+	    private Bahnsteig bahnsteig;
 	
-	    TimeTableColumn(Bahnsteig b, List<TimeTableRow> rows){
-	        this.rows = rows;
-	        bahnsteig = b;
+	    TimeTableColumn(Bahnsteig b){
+	        this.bahnsteig = b;
 	    }
+	    
+	    public List<TimeTableRow> getRows() {
+	    	return TimeTable.this.rows;
+	    }
+
+		public Bahnsteig getBahnsteig() {
+			return bahnsteig;
+		}
 	}
 	
-	class TimeTableRow{
+	class TimeTableRow {
 	    long time;
-	    List<TimeTableColumn> cols;
-	    List<TimeTableData> fields;
+	    private List<TimeTableData> fields;
 	
-	    TimeTableRow(long time, List<TimeTableColumn> cols){
-	        this.cols = cols;
+	    TimeTableRow(long time) {
 	        this.time = time;
 	        fields = new ArrayList<>();
 	
-	        for(TimeTableColumn ttc : cols){
+	        for (TimeTableColumn ttc : cols){
 	            TimeTableData ttd = new TimeTableData(ttc, this);
 	            fields.add(ttd);
 	        }
 	    }
+	    
+	    public List<TimeTableColumn> getCols() {
+	    	return TimeTable.this.cols;
+	    }
+
+		public Iterator<TimeTableData> dataIterator() {
+			return fields.iterator();
+		}
 	}
 	
-	class TimeTableData{
-	    List<FahrplanHalt> zuege;
-	    TimeTableRow row;
-	    TimeTableColumn col;
+	class TimeTableData {
+	    private List<FahrplanHalt> zuege;
+	    private TimeTableRow row;
+	    private TimeTableColumn col;
 	
-	    TimeTableData(TimeTableColumn col, TimeTableRow row){
+	    TimeTableData(TimeTableColumn col, TimeTableRow row) {
 	        this.col = col;
 	        this.row = row;
-	        zuege = new ArrayList<FahrplanHalt>();
+	        this.zuege =  new ArrayList<FahrplanHalt>();
 	    }
+
+		public TimeTableColumn getCol() {
+			return col;
+		}
+
+		public TimeTableRow getRow() {
+			return row;
+		}
+
+		public List<FahrplanHalt> getZuege() {
+			return zuege;
+		}
 	}
 	
 	
@@ -63,11 +88,11 @@ public class TimeTable {
         refresh = new ArrayList<TimeTableData>();
 
         for(Bahnsteig b : stellwerk.getBahnsteige()){
-            cols.add(new TimeTableColumn(b, rows));
+            cols.add(new TimeTableColumn(b));
         }
 
         //erste Zeile erstellen, um Inhalt zu haben
-        TimeTableRow ttr = new TimeTableRow(stellwerk.getSpielzeit(), cols);
+        TimeTableRow ttr = new TimeTableRow(stellwerk.getSpielzeit());
         rows.add(ttr);
     }
 
@@ -87,8 +112,8 @@ public class TimeTable {
         for(TimeTableRow ttr : rows) {
             if(ttr.time >= fh.getTatsaechlicheAnkunft() && ttr.time <= fh.getTatsaechlicheAbfahrt() + 1000*60){
                 for(TimeTableData ttd : ttr.fields){
-                    if(fh.getBahnsteig().getId() == ttd.col.bahnsteig.getId()){
-                        ttd.zuege.add(fh);
+                    if(fh.getBahnsteig().getId() == ttd.col.getBahnsteig().getId()){
+                        ttd.getZuege().add(fh);
                         if(!refresh.contains(ttd)) refresh.add(ttd);
                         counter++;
                     }
@@ -100,13 +125,13 @@ public class TimeTable {
         if(haltInMinuten > counter){
             TimeTableRow lastRow = rows.get(rows.size() - 1);
             while(fh.getAbfahrt() + fh.getZug().getVerspaetungInMiliSekunden() > lastRow.time){
-                lastRow = new TimeTableRow(lastRow.time + 1000*60, cols);
+                lastRow = new TimeTableRow(lastRow.time + 1000*60);
                 rows.add(lastRow);
 
                 if(lastRow.time >= fh.getTatsaechlicheAnkunft() && lastRow.time <= fh.getTatsaechlicheAbfahrt() + 1000*60){
                     for(TimeTableData ttd : lastRow.fields){
-                        if(fh.getBahnsteig().getId() == ttd.col.bahnsteig.getId()){
-                            ttd.zuege.add(fh);
+                        if(fh.getBahnsteig().getId() == ttd.col.getBahnsteig().getId()){
+                            ttd.getZuege().add(fh);
                             if(!refresh.contains(ttd)) refresh.add(ttd);
                         }
                     }
@@ -139,14 +164,14 @@ public class TimeTable {
         for(TimeTableRow ttr : rows){
             for(TimeTableData ttd : ttr.fields){
                 int counter = -1;
-                for (int i = 0; i < ttd.zuege.size(); i++) {
-                    FahrplanHalt fh = ttd.zuege.get(i);
+                for (int i = 0; i < ttd.getZuege().size(); i++) {
+                    FahrplanHalt fh = ttd.getZuege().get(i);
                     if(fh.getId() == remove.getId()){
                         counter = i;
                     }
                 }
 
-                if(counter >= 0) ttd.zuege.remove(counter);
+                if(counter >= 0) ttd.getZuege().remove(counter);
             }
         }
     }
@@ -164,5 +189,10 @@ public class TimeTable {
             rows.remove(ttr);
         }
     }
+
+
+	public Iterator<TimeTableRow> rowIterator() {
+		return rows.iterator();
+	}
 }
 

--- a/Plugin Gleisbelegung/src/com/gleisbelegung/TimeTable.java
+++ b/Plugin Gleisbelegung/src/com/gleisbelegung/TimeTable.java
@@ -18,10 +18,6 @@ public class TimeTable {
 	        this.bahnsteig = b;
 	    }
 	    
-	    public List<TimeTableRow> getRows() {
-	    	return TimeTable.this.rows;
-	    }
-
 		public Bahnsteig getBahnsteig() {
 			return bahnsteig;
 		}
@@ -39,10 +35,6 @@ public class TimeTable {
 	            TimeTableData ttd = new TimeTableData(ttc, this);
 	            fields.add(ttd);
 	        }
-	    }
-	    
-	    public List<TimeTableColumn> getCols() {
-	    	return TimeTable.this.cols;
 	    }
 
 		public Iterator<TimeTableData> dataIterator() {

--- a/Plugin Gleisbelegung/src/com/gleisbelegung/TimeTable.java
+++ b/Plugin Gleisbelegung/src/com/gleisbelegung/TimeTable.java
@@ -9,6 +9,47 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class TimeTable {
+
+	class TimeTableColumn{
+	    Bahnsteig bahnsteig;
+	    List<TimeTableRow> rows;
+	
+	    TimeTableColumn(Bahnsteig b, List<TimeTableRow> rows){
+	        this.rows = rows;
+	        bahnsteig = b;
+	    }
+	}
+	
+	class TimeTableRow{
+	    long time;
+	    List<TimeTableColumn> cols;
+	    List<TimeTableData> fields;
+	
+	    TimeTableRow(long time, List<TimeTableColumn> cols){
+	        this.cols = cols;
+	        this.time = time;
+	        fields = new ArrayList<>();
+	
+	        for(TimeTableColumn ttc : cols){
+	            TimeTableData ttd = new TimeTableData(ttc, this);
+	            fields.add(ttd);
+	        }
+	    }
+	}
+	
+	class TimeTableData{
+	    List<FahrplanHalt> zuege;
+	    TimeTableRow row;
+	    TimeTableColumn col;
+	
+	    TimeTableData(TimeTableColumn col, TimeTableRow row){
+	        this.col = col;
+	        this.row = row;
+	        zuege = new ArrayList<FahrplanHalt>();
+	    }
+	}
+	
+	
     List<TimeTableColumn> cols; //Spalten
     List<TimeTableRow> rows;    //Reihen
     List<TimeTableData> refresh;
@@ -125,42 +166,3 @@ public class TimeTable {
     }
 }
 
-
-class TimeTableColumn{
-    Bahnsteig bahnsteig;
-    List<TimeTableRow> rows;
-
-    TimeTableColumn(Bahnsteig b, List<TimeTableRow> rows){
-        this.rows = rows;
-        bahnsteig = b;
-    }
-}
-
-class TimeTableRow{
-    long time;
-    List<TimeTableColumn> cols;
-    List<TimeTableData> fields;
-
-    TimeTableRow(long time, List<TimeTableColumn> cols){
-        this.cols = cols;
-        this.time = time;
-        fields = new ArrayList<>();
-
-        for(TimeTableColumn ttc : cols){
-            TimeTableData ttd = new TimeTableData(ttc, this);
-            fields.add(ttd);
-        }
-    }
-}
-
-class TimeTableData{
-    List<FahrplanHalt> zuege;
-    TimeTableRow row;
-    TimeTableColumn col;
-
-    TimeTableData(TimeTableColumn col, TimeTableRow row){
-        this.col = col;
-        this.row = row;
-        zuege = new ArrayList<FahrplanHalt>();
-    }
-}

--- a/Plugin Gleisbelegung/src/com/gleisbelegung/TimeTable.java
+++ b/Plugin Gleisbelegung/src/com/gleisbelegung/TimeTable.java
@@ -29,7 +29,7 @@ public class TimeTable {
     }
 
 
-    public void addTrain(Zug z){
+    public void addZug(Zug z){
         for(FahrplanHalt fh : z.getFahrplan()){
             addFahrplanHalt(fh);
         }
@@ -53,13 +53,24 @@ public class TimeTable {
         }
     }
 
-    public void removeTrain(Zug z){
+    public void updateZug(Zug z){
+        for(FahrplanHalt fh : z.getFahrplan()){
+            updateFahrplanhalt(fh);
+        }
+    }
+
+    public void updateFahrplanhalt(FahrplanHalt fh){
 
     }
 
-    public void updateTrain(Zug z){
-        removeTrain(z);
-        addTrain(z);
+    public void removeZug(Zug z){
+        for(FahrplanHalt fh : z.getFahrplan()){
+            removeFahrplanhalt(fh);
+        }
+    }
+
+    public void removeFahrplanhalt(FahrplanHalt fh){
+        //kein Ahnung
     }
 }
 

--- a/Plugin Gleisbelegung/src/com/gleisbelegung/TimeTable.java
+++ b/Plugin Gleisbelegung/src/com/gleisbelegung/TimeTable.java
@@ -1,0 +1,104 @@
+package com.gleisbelegung;
+
+import com.gleisbelegung.lib.Stellwerk;
+import com.gleisbelegung.lib.data.Bahnsteig;
+import com.gleisbelegung.lib.data.FahrplanHalt;
+import com.gleisbelegung.lib.data.Zug;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class TimeTable {
+    List<TimeTableColumn> cols; //Spalten
+    List<TimeTableRow> rows;    //Reihen
+    private Stellwerk stellwerk;
+
+    public TimeTable(Stellwerk stellwerk){
+        this.stellwerk = stellwerk;
+
+        cols = new ArrayList<TimeTableColumn>();
+        rows = new ArrayList<TimeTableRow>();
+
+        for(Bahnsteig b : stellwerk.getBahnsteige()){
+            cols.add(new TimeTableColumn(b, rows));
+        }
+
+        //erste Zeile erstellen, um Inhalt zu haben
+        TimeTableRow ttr = new TimeTableRow(stellwerk.getSpielzeit(), cols);
+        rows.add(ttr);
+    }
+
+
+    public void addTrain(Zug z){
+        for(FahrplanHalt fh : z.getFahrplan()){
+            addFahrplanHalt(fh);
+        }
+    }
+
+    public void addFahrplanHalt(FahrplanHalt fh){
+        //TODO Ein Zug wird geändert, hier kann die Kollisionsabfrage und Benachrichtigung erfolgen
+
+        TimeTableRow lastRow = rows.get(rows.size() - 1);
+        while(fh.getAbfahrt() + fh.getZug().getVerspaetungInMiliSekunden() > lastRow.time){
+            lastRow = new TimeTableRow(lastRow.time + 1000*60, cols);
+            rows.add(lastRow);
+
+            if(lastRow.time >= fh.getTatsaechlicheAnkunf() && lastRow.time <= fh.getTatsaechlicheAbfahrt()){
+                for(TimeTableData ttd : lastRow.fields){
+                    if(fh.getBahnsteig().getId() == ttd.col.bahnsteig.getId()){
+                        ttd.zuege.add(fh.getZug());
+                    }
+                }
+            }
+        }
+    }
+
+    public void removeTrain(Zug z){
+
+    }
+
+    public void updateTrain(Zug z){
+        removeTrain(z);
+        addTrain(z);
+    }
+}
+
+
+class TimeTableColumn{
+    Bahnsteig bahnsteig;
+    List<TimeTableRow> rows;
+
+    TimeTableColumn(Bahnsteig b, List<TimeTableRow> rows){
+        this.rows = rows;
+        bahnsteig = b;
+    }
+}
+
+class TimeTableRow{
+    long time;
+    List<TimeTableColumn> cols;
+    List<TimeTableData> fields;
+
+    TimeTableRow(long time, List<TimeTableColumn> cols){
+        this.cols = cols;
+        this.time = time;
+        fields = new ArrayList<>();
+
+        for(TimeTableColumn ttc : cols){
+            TimeTableData ttd = new TimeTableData(ttc, this);
+            fields.add(ttd);
+        }
+    }
+}
+
+class TimeTableData{
+    List<Zug> zuege;
+    TimeTableRow row;
+    TimeTableColumn col;
+
+    TimeTableData(TimeTableColumn col, TimeTableRow row){
+        this.col = col;
+        this.row = row;
+        zuege = new ArrayList<Zug>();
+    }
+}

--- a/Plugin Gleisbelegung/src/com/gleisbelegung/lib/Stellwerk.java
+++ b/Plugin Gleisbelegung/src/com/gleisbelegung/lib/Stellwerk.java
@@ -7,6 +7,8 @@ import com.gleisbelegung.lib.data.Zug;
 import java.io.IOException;
 import java.net.Socket;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 public class Stellwerk {
     private static String host;
@@ -21,7 +23,7 @@ public class Stellwerk {
     long letzteAktualisierung;
 
     private ArrayList<Bahnhof> bahnhoefe;
-    ArrayList<Zug> zuege;
+    private ArrayList<Zug> zuege;
 
     private static Verbindung v;
 
@@ -111,8 +113,20 @@ public class Stellwerk {
     public ArrayList<Bahnhof> getBahnhoefe() {
         return bahnhoefe;
     }
-    public ArrayList<Zug> getZuege() {
-        return zuege;
+    public List<Zug> getZuege() {
+    	synchronized(zuege) {
+    		return Collections.unmodifiableList(zuege);
+    	}
+    }
+    public void addZug(Zug zug) {
+    	synchronized(zuege) {
+    		zuege.add(zug);
+    	}
+    }
+    public void removeZuege(List<Zug> zuege) {
+    	synchronized(this.zuege) {
+    		this.zuege.removeAll(zuege);
+    	}
     }
     public long getSpielzeit() {
         return spielzeit;

--- a/Plugin Gleisbelegung/src/com/gleisbelegung/lib/Stellwerk.java
+++ b/Plugin Gleisbelegung/src/com/gleisbelegung/lib/Stellwerk.java
@@ -64,11 +64,11 @@ public class Stellwerk {
             }
             bahnhofsName[i] = bahnsteige[i].replaceAll("\\P{L}+", "");
             if(letzterBahnhofsName.equals(bahnhofsName[i]) && bahnhoefe.size() > 0){
-                bahnhoefe.get(bahnhoefe.size()-1).getBahnsteige().add(new Bahnsteig(bahnhoefe.get(bahnhoefe.size()-1), bahnsteigsName, i));
+                bahnhoefe.get(bahnhoefe.size()-1).addBahnsteig(new Bahnsteig(bahnhoefe.get(bahnhoefe.size()-1), bahnsteigsName, i));
             } else {
                 letzterBahnhofsName = bahnhofsName[i];
                 bahnhoefe.add(new Bahnhof(bahnhoefe.size(), letzterBahnhofsName));
-                bahnhoefe.get(bahnhoefe.size()-1).getBahnsteige().add(new Bahnsteig(bahnhoefe.get(bahnhoefe.size()-1), bahnsteigsName, i));
+                bahnhoefe.get(bahnhoefe.size()-1).addBahnsteig(new Bahnsteig(bahnhoefe.get(bahnhoefe.size()-1), bahnsteigsName, i));
             }
         }
     }
@@ -115,7 +115,7 @@ public class Stellwerk {
     }
     public List<Zug> getZuege() {
     	synchronized(zuege) {
-    		return Collections.unmodifiableList(zuege);
+    		return Collections.unmodifiableList(new ArrayList<Zug>(zuege));
     	}
     }
     public void addZug(Zug zug) {

--- a/Plugin Gleisbelegung/src/com/gleisbelegung/lib/Stellwerk.java
+++ b/Plugin Gleisbelegung/src/com/gleisbelegung/lib/Stellwerk.java
@@ -85,6 +85,13 @@ public class Stellwerk {
         v.aktualisiereSimZeit();
     }
 
+    public List<Bahnsteig> getBahnsteige(){
+        List<Bahnsteig> bahnsteige = new ArrayList<Bahnsteig>();
+        for(Bahnhof b : bahnhoefe){
+            bahnsteige.addAll(b.getBahnsteige());
+        }
+        return bahnsteige;
+    }
     public int getAnzahlBahnsteige(){
         int counter = 0;
         for(Bahnhof b : bahnhoefe){

--- a/Plugin Gleisbelegung/src/com/gleisbelegung/lib/Verbindung.java
+++ b/Plugin Gleisbelegung/src/com/gleisbelegung/lib/Verbindung.java
@@ -152,7 +152,7 @@ public class Verbindung {
         for (XML xmlZug : zugliste.getInternXML()) {
             try {
                 boolean exists = false;
-                for (Zug z : stellwerk.zuege) {
+                for (Zug z : stellwerk.getZuege()) {
                     try {
                         if (!xmlZug.get("zid").equals("") && Integer.parseInt(xmlZug.get("zid")) == z.getZugId()) {
                             exists = true;
@@ -166,7 +166,7 @@ public class Verbindung {
 
                 if (!exists && !xmlZug.get("zid").equals("") && !xmlZug.get("name").equals("")) {
                     //System.out.println("INFORMATION: " + zugliste.get(i).get(0).get(1)[1] + " wurde hinzugefügt!");
-                    stellwerk.zuege.add(new Zug(Integer.parseInt(xmlZug.get("zid")), xmlZug.get("name")));
+                    stellwerk.addZug(new Zug(Integer.parseInt(xmlZug.get("zid")), xmlZug.get("name")));
                 }
             } catch (Exception e) {
                 System.out.println("FEHLER: Zuglistenaktualisierungsfehler!");
@@ -176,9 +176,7 @@ public class Verbindung {
 
         ArrayList<Zug> removing = new ArrayList<>();
 
-        for (int j = 0; j < stellwerk.zuege.size(); j++) {
-            Zug z = stellwerk.zuege.get(j);
-
+        for (Zug z : stellwerk.getZuege()) {
             try {
                 boolean updateNeeded = false;
                 setSocketCode("<zugdetails zid='" + z.getZugId() + "'/>");
@@ -323,13 +321,9 @@ public class Verbindung {
                 e.printStackTrace();
             }
         }
+        stellwerk.removeZuege(removing);
 
-        for (Zug z : removing) {
-            //System.out.println("INFORMATION: " + z.getZugName() + " wurde entfernt.");
-            stellwerk.zuege.remove(z);
-        }
-
-        for (Zug z : stellwerk.zuege) {
+        for (Zug z : stellwerk.getZuege()) {
             try {
                 if (z != null && z.getFahrplan() != null) {
                     for (FahrplanHalt fh : z.getFahrplan()) {
@@ -378,7 +372,7 @@ public class Verbindung {
                 }
             }
 
-            for (Zug z : stellwerk.zuege) {
+            for (Zug z : stellwerk.getZuege()) {
                 if (z.getZugId() == Integer.parseInt(out)) {
                     return z;
                 }

--- a/Plugin Gleisbelegung/src/com/gleisbelegung/lib/Verbindung.java
+++ b/Plugin Gleisbelegung/src/com/gleisbelegung/lib/Verbindung.java
@@ -387,8 +387,9 @@ public class Verbindung {
 
     private Bahnsteig sucheBahnsteig(String name) {
         for (Bahnhof bahnhof : stellwerk.getBahnhoefe()) {
-            for (Bahnsteig bahnsteig : bahnhof.getBahnsteige()) {
-                if (bahnsteig.getName().equals(name)) return bahnsteig;
+            Bahnsteig bst = bahnhof.getBahnsteigByName(name);
+            if (bst != null) {
+              return bst;
             }
         }
         return null;

--- a/Plugin Gleisbelegung/src/com/gleisbelegung/lib/data/Bahnhof.java
+++ b/Plugin Gleisbelegung/src/com/gleisbelegung/lib/data/Bahnhof.java
@@ -157,6 +157,11 @@ public class Bahnhof {
       return Collections.unmodifiableList(bahnhofTeile);
     }
   }
+    public BahnhofTeil getBahnhofTeile(int index) {
+        synchronized (bahnhofTeile) {
+            return bahnhofTeile.get(index);
+        }
+    }
 
   public void addBahnhofLabel(LabelContainer bahnhofLabel, List<Bahnsteig> bahnsteige) {
     BahnhofTeil bt = new BahnhofTeil(bahnhofLabel, bahnsteige);
@@ -178,7 +183,7 @@ public class Bahnhof {
     return alternativName;
   }
 
-  private void einstellungen(BahnhofTeil bt) {
+  public void einstellungen(BahnhofTeil bt) {
     Einstellungen.fenster.gleisbelegung.zeigeOrderIds();
     Stage stage = new Stage();
 

--- a/Plugin Gleisbelegung/src/com/gleisbelegung/lib/data/Bahnhof.java
+++ b/Plugin Gleisbelegung/src/com/gleisbelegung/lib/data/Bahnhof.java
@@ -13,6 +13,7 @@ import javafx.scene.text.Font;
 import javafx.stage.Stage;
 
 import javafx.scene.shape.Line;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -26,327 +27,326 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 
 public class Bahnhof {
-  /**
-   * Vebindung zwischen Bahnhof.this and BahnhofVerbindung.ziel
-   *
-   */
-  private class BahnhofVerbindung {
-    private double laenge; // dead variable
-    private Line linie;
-    private Vec2d linienPos;
-    private Bahnhof ziel;
+    /**
+     * Vebindung zwischen Bahnhof.this and BahnhofVerbindung.ziel
+     */
+    private class BahnhofVerbindung {
+        private double laenge; // dead variable
+        private Line linie;
+        private Vec2d linienPos;
+        private Bahnhof ziel;
 
-    public BahnhofVerbindung(Bahnhof bahnhof, double laenge, Line linie, Vec2d linienPos) {
-      this.laenge = laenge;
-      this.linie = linie;
-      this.linienPos = linienPos;
-      ziel = bahnhof;
+        public BahnhofVerbindung(Bahnhof bahnhof, double laenge, Line linie, Vec2d linienPos) {
+            this.laenge = laenge;
+            this.linie = linie;
+            this.linienPos = linienPos;
+            ziel = bahnhof;
+        }
+
+        public void setLinienPos(Vec2d linienPos) {
+            this.linienPos = linienPos;
+        }
+
+        public Vec2d getLinienPos() {
+            return linienPos;
+        }
+
+        public Bahnhof getStartBahnhof() {
+            return Bahnhof.this;
+        }
+
+        public Bahnhof getZielBahnhof() {
+            return ziel;
+        }
     }
 
-    public void setLinienPos(Vec2d linienPos) {
-      this.linienPos = linienPos;
+    private class BahnhofTeil implements Iterable<Bahnsteig> {
+        private LabelContainer bahnhofsLabel;
+        private List<Bahnsteig> bahnsteige;
+
+        public BahnhofTeil(LabelContainer bahnhofsLabel, List<Bahnsteig> bahnsteige) {
+            this.bahnhofsLabel = bahnhofsLabel;
+            this.bahnsteige = bahnsteige;
+
+        }
+
+        void hervorheben() {
+            for (Bahnsteig b : bahnsteige) {
+                b.hebeHervor();
+            }
+        }
+
+        public int getBahnsteigSize() {
+            return bahnsteige.size();
+        }
+
+        public Iterator<Bahnsteig> iterator() {
+            return bahnsteige.iterator();
+        }
     }
 
-    public Vec2d getLinienPos() {
-      return linienPos;
+    private int id;
+    private String name;
+    private String alternativName = "";
+    private Map<String, Bahnsteig> bahnsteige = new HashMap<>();
+    private List<Bahnsteig> bahnsteigListe = new ArrayList<>();
+    private List<BahnhofTeil> bahnhofTeile = new ArrayList<>();
+    private Map<Integer, BahnhofVerbindung> bahnhofVerbindungen = new HashMap<>();
+    private boolean sichtbar;
+    private Vec2d pos;
+    private Bahnsteig lastBahnsteig;
+
+    public Bahnhof(int id, String name) {
+        this.id = id;
+        this.name = name;
+        pos = new Vec2d(30, id * 40 + 40);
     }
 
-    public Bahnhof getStartBahnhof() {
-      return Bahnhof.this;
+    private BahnhofVerbindung getVerbindung(Bahnhof bahnhof) {
+        synchronized (bahnhofVerbindungen) {
+            return bahnhofVerbindungen.get(Integer.valueOf(bahnhof.id));
+        }
     }
 
-    public Bahnhof getZielBahnhof() {
-      return ziel;
-    }
-  }
-
-  private class BahnhofTeil implements Iterable<Bahnsteig> {
-    private LabelContainer bahnhofsLabel;
-    private List<Bahnsteig> bahnsteige;
-
-    public BahnhofTeil(LabelContainer bahnhofsLabel, List<Bahnsteig> bahnsteige) {
-      this.bahnhofsLabel = bahnhofsLabel;
-      this.bahnsteige = bahnsteige;
-
+    public int getId() {
+        return id;
     }
 
-    void hervorheben() {
-      for (Bahnsteig b : bahnsteige) {
-        b.hebeHervor();
-      }
+    public String getName() {
+        return name;
     }
 
-    public int getBahnsteigSize() {
-      return bahnsteige.size();
+    public Collection<Bahnsteig> getBahnsteige() {
+        synchronized (bahnsteigListe) {
+            return Collections.unmodifiableList(new ArrayList<>(bahnsteigListe));
+        }
     }
 
-    public Iterator<Bahnsteig> iterator() {
-      return bahnsteige.iterator();
-    }
-  }
-
-  private int id;
-  private String name;
-  private String alternativName = "";
-  private Map<String, Bahnsteig> bahnsteige = new HashMap<>();
-  private List<Bahnsteig> bahnsteigListe = new ArrayList<>();
-  private List<BahnhofTeil> bahnhofTeile = new ArrayList<>();
-  private Map<Integer, BahnhofVerbindung> bahnhofVerbindungen = new HashMap<>();
-  private boolean sichtbar;
-  private Vec2d pos;
-  private Bahnsteig lastBahnsteig;
-
-  public Bahnhof(int id, String name) {
-    this.id = id;
-    this.name = name;
-    pos = new Vec2d(30, id * 40 + 40);
-  }
-
-  private BahnhofVerbindung getVerbindung(Bahnhof bahnhof) {
-    synchronized (bahnhofVerbindungen) {
-      return bahnhofVerbindungen.get(Integer.valueOf(bahnhof.id));
-    }
-  }
-
-  public int getId() {
-    return id;
-  }
-
-  public String getName() {
-    return name;
-  }
-
-  public Collection<Bahnsteig> getBahnsteige() {
-    synchronized (bahnsteigListe) {
-      return Collections.unmodifiableList(new ArrayList<>(bahnsteigListe));
-    }
-  }
-
-  public Bahnsteig getBahnsteig(int index) {
-    synchronized (bahnsteigListe) {
-      return bahnsteigListe.get(index);
-    }
-  }
-
-  public int getAnzahlBahnsteige() {
-    synchronized (bahnsteige) {
-      return bahnsteige.size();
-    }
-  }
-
-  public boolean isSichtbar() {
-    synchronized (bahnsteige) {
-      for (Bahnsteig b : bahnsteige.values()) {
-        if (!b.isSichtbar())
-          return false;
-
-      }
-    }
-    return true;
-  }
-
-  public void setSichtbar(boolean sichtbar) {
-    synchronized (bahnsteige) {
-      for (Bahnsteig b : bahnsteige.values())
-        b.setSichtbar(sichtbar);
-    }
-  }
-
-  public List<BahnhofTeil> getBahnhofTeile() {
-    synchronized (bahnhofTeile) {
-      return Collections.unmodifiableList(bahnhofTeile);
-    }
-  }
-
-  public void addBahnhofLabel(LabelContainer bahnhofLabel, List<Bahnsteig> bahnsteige) {
-    BahnhofTeil bt = new BahnhofTeil(bahnhofLabel, bahnsteige);
-    synchronized (bahnhofTeile) {
-      bahnhofTeile.add(bt);
+    public Bahnsteig getBahnsteig(int index) {
+        synchronized (bahnsteigListe) {
+            return bahnsteigListe.get(index);
+        }
     }
 
-    bahnhofLabel.getLabel().setOnMouseClicked(e -> {
-      if (e.getButton() == MouseButton.PRIMARY) {
-        bt.hervorheben();
-        System.out.println(bt.getBahnsteigSize());
-      } else if (e.getButton() == MouseButton.SECONDARY) {
-        einstellungen(bt);
-      }
-    });
-  }
-
-  public String getAlternativName() {
-    return alternativName;
-  }
-
-  private void einstellungen(BahnhofTeil bt) {
-    Einstellungen.fenster.gleisbelegung.zeigeOrderIds();
-    Stage stage = new Stage();
-
-    Label name = new Label("Name:");
-    name.setStyle("-fx-text-fill: white;");
-    name.setFont(Font.font(Einstellungen.schriftgroesse));
-    name.setTranslateY(25);
-    name.setTranslateX(25);
-
-    TextField tname = new TextField(alternativName);
-    tname.setFont(Font.font(Einstellungen.schriftgroesse - 3));
-    tname.setTranslateX(25);
-    tname.setTranslateY(60);
-
-    Label l = new Label("Reihenfolge festlegen:");
-    l.setStyle("-fx-text-fill: white;");
-    l.setFont(Font.font(Einstellungen.schriftgroesse));
-    l.setTranslateX(25);
-    l.setTranslateY(95);
-
-    TextField tf = new TextField(String.valueOf(bahnsteige.get(0).getOrderId() + 1));
-    tf.setFont(Font.font(Einstellungen.schriftgroesse - 3));
-    tf.setTranslateX(25);
-    tf.setTranslateY(130);
-
-    Button b = new Button("Speichern");
-    b.setFont(Font.font(Einstellungen.schriftgroesse));
-    b.setTranslateX(25);
-    b.setTranslateY(190);
-    b.setOnAction(e -> {
-      int order = Integer.parseInt(tf.getText()) - 1;
-      for (Bahnsteig ba : bt) {
-        ba.setOrderId(order);
-        alternativName = tname.getText();
-      }
-
-      stage.close();
-      Einstellungen.fenster.gleisbelegung.versteckeOrderIds();
-      Einstellungen.fenster.gleisbelegung.sortiereGleise();
-      Einstellungen.fenster.stellwerksuebersicht.aktualisiereBahnhofsNamen();
-    });
-
-    Pane p = new Pane(name, tname, l, tf, b);
-    p.setStyle("-fx-background-color: #303030;");
-    p.setMinSize(500, 200);
-    p.setMaxSize(500, 200);
-
-    Scene scene = new Scene(p, 300, 250);
-
-    stage.setScene(scene);
-    stage.show();
-    stage.setAlwaysOnTop(true);
-
-    stage.setOnCloseRequest(e -> {
-      Einstellungen.fenster.gleisbelegung.versteckeOrderIds();
-    });
-  }
-
-  @Override
-  public String toString() {
-    return "Bahnhof{" + "id=" + id + ", name='" + name + '\'' + ", bahnsteige=" + bahnsteige + '}';
-  }
-
-  public Vec2d getPos() {
-    return pos;
-  }
-
-  public void setPos(Vec2d pos) {
-    this.pos = pos;
-  }
-
-  public Collection<BahnhofVerbindung> getBahnhofVerbindungen() {
-    synchronized (bahnhofVerbindungen) {
-      return Collections.unmodifiableCollection(bahnhofVerbindungen.values());
-    }
-  }
-
-  public void addBahnhofVerbindung(Bahnhof bahnhof, double laenge, Line linie, Vec2d linienPos) {
-    BahnhofVerbindung verbindung = new BahnhofVerbindung(bahnhof, laenge, linie, linienPos);
-    synchronized (bahnhofVerbindungen) {
-      bahnhofVerbindungen.put(Integer.valueOf(bahnhof.id), verbindung);
-    }
-  }
-
-  public Line getLinie(Bahnhof bahnhof) {
-    BahnhofVerbindung bv = getVerbindung(bahnhof);
-
-    if (bv == null) {
-      return null;
+    public int getAnzahlBahnsteige() {
+        synchronized (bahnsteige) {
+            return bahnsteige.size();
+        }
     }
 
-    return bv.linie;
-  }
+    public boolean isSichtbar() {
+        synchronized (bahnsteige) {
+            for (Bahnsteig b : bahnsteige.values()) {
+                if (!b.isSichtbar())
+                    return false;
 
-  public Set<Bahnhof> getVerbindungsBahnhoefe() {
-    Collection<BahnhofVerbindung> bvs = getBahnhofVerbindungen();
-    Set<Bahnhof> bahnhofSet = new HashSet<>();
-    for (BahnhofVerbindung bv : bvs) {
-      bahnhofSet.add(bv.getZielBahnhof());
+            }
+        }
+        return true;
     }
 
-    return bahnhofSet;
-  }
-
-  public Vec2d getLinienPos(Bahnhof bahnhof) {
-    BahnhofVerbindung bv = getVerbindung(bahnhof);
-    if (bv == null) {
-      return null;
+    public void setSichtbar(boolean sichtbar) {
+        synchronized (bahnsteige) {
+            for (Bahnsteig b : bahnsteige.values())
+                b.setSichtbar(sichtbar);
+        }
     }
 
-    return bv.getLinienPos();
-  }
-
-  public boolean setLinienPos(Bahnhof bahnhof, Vec2d linienPos) {
-    BahnhofVerbindung bv = getVerbindung(bahnhof);
-    if (bv == null) {
-      return false;
+    public List<BahnhofTeil> getBahnhofTeile() {
+        synchronized (bahnhofTeile) {
+            return Collections.unmodifiableList(bahnhofTeile);
+        }
     }
 
-    bv.setLinienPos(linienPos);
+    public void addBahnhofLabel(LabelContainer bahnhofLabel, List<Bahnsteig> bahnsteige) {
+        BahnhofTeil bt = new BahnhofTeil(bahnhofLabel, bahnsteige);
+        synchronized (bahnhofTeile) {
+            bahnhofTeile.add(bt);
+        }
 
-    return true;
-  }
-
-  public Bahnsteig getBahnsteigByName(String name) {
-    synchronized (bahnsteige) {
-      return bahnsteige.get(name);
-    }
-  }
-
-  public void addBahnsteig(Bahnsteig bahnsteig) {
-    synchronized (bahnsteige) {
-      this.bahnsteige.put(bahnsteig.getName(), bahnsteig);
-      this.lastBahnsteig = bahnsteig;
-    }
-    synchronized (bahnsteigListe) {
-      bahnsteigListe.add(bahnsteig);
-    }
-  }
-
-  public Bahnsteig getLastBahnsteig() {
-    synchronized (bahnsteige) {
-      return lastBahnsteig;
-    }
-  }
-
-  public void clearBahnhofVerbindungen() {
-    synchronized (bahnhofVerbindungen) {
-      this.bahnhofVerbindungen.clear();
+        bahnhofLabel.getLabel().setOnMouseClicked(e -> {
+            if (e.getButton() == MouseButton.PRIMARY) {
+                bt.hervorheben();
+                System.out.println(bt.getBahnsteigSize());
+            } else if (e.getButton() == MouseButton.SECONDARY) {
+                einstellungen(bt);
+            }
+        });
     }
 
-  }
-
-  public SortedMap<Integer, Bahnsteig> getBahnsteigOrderMap() {
-    SortedMap<Integer, Bahnsteig> bahnsteigMap = new TreeMap<>();
-    synchronized (bahnsteige) {
-      for (Bahnsteig bst : bahnsteige.values()) {
-        bahnsteigMap.put(Integer.valueOf(bst.getOrderId()), bst);
-      }
+    public String getAlternativName() {
+        return alternativName;
     }
 
-    return bahnsteigMap;
-  }
+    private void einstellungen(BahnhofTeil bt) {
+        Einstellungen.fenster.gleisbelegung.zeigeOrderIds();
+        Stage stage = new Stage();
 
-  public void clearBahnhofTeile() {
-    synchronized (bahnhofTeile) {
-      bahnhofTeile.clear();
+        Label name = new Label("Name:");
+        name.setStyle("-fx-text-fill: white;");
+        name.setFont(Font.font(Einstellungen.schriftgroesse));
+        name.setTranslateY(25);
+        name.setTranslateX(25);
+
+        TextField tname = new TextField(alternativName);
+        tname.setFont(Font.font(Einstellungen.schriftgroesse - 3));
+        tname.setTranslateX(25);
+        tname.setTranslateY(60);
+
+        Label l = new Label("Reihenfolge festlegen:");
+        l.setStyle("-fx-text-fill: white;");
+        l.setFont(Font.font(Einstellungen.schriftgroesse));
+        l.setTranslateX(25);
+        l.setTranslateY(95);
+
+        TextField tf = new TextField(String.valueOf(bahnsteige.get(0).getOrderId() + 1));
+        tf.setFont(Font.font(Einstellungen.schriftgroesse - 3));
+        tf.setTranslateX(25);
+        tf.setTranslateY(130);
+
+        Button b = new Button("Speichern");
+        b.setFont(Font.font(Einstellungen.schriftgroesse));
+        b.setTranslateX(25);
+        b.setTranslateY(190);
+        b.setOnAction(e -> {
+            int order = Integer.parseInt(tf.getText()) - 1;
+            for (Bahnsteig ba : bt) {
+                ba.setOrderId(order);
+                alternativName = tname.getText();
+            }
+
+            stage.close();
+            Einstellungen.fenster.gleisbelegung.versteckeOrderIds();
+            Einstellungen.fenster.gleisbelegung.sortiereGleise();
+            Einstellungen.fenster.stellwerksuebersicht.aktualisiereBahnhofsNamen();
+        });
+
+        Pane p = new Pane(name, tname, l, tf, b);
+        p.setStyle("-fx-background-color: #303030;");
+        p.setMinSize(500, 200);
+        p.setMaxSize(500, 200);
+
+        Scene scene = new Scene(p, 300, 250);
+
+        stage.setScene(scene);
+        stage.show();
+        stage.setAlwaysOnTop(true);
+
+        stage.setOnCloseRequest(e -> {
+            Einstellungen.fenster.gleisbelegung.versteckeOrderIds();
+        });
     }
 
-  }
+    @Override
+    public String toString() {
+        return "Bahnhof{" + "id=" + id + ", name='" + name + '\'' + ", bahnsteige=" + bahnsteige + '}';
+    }
+
+    public Vec2d getPos() {
+        return pos;
+    }
+
+    public void setPos(Vec2d pos) {
+        this.pos = pos;
+    }
+
+    public Collection<BahnhofVerbindung> getBahnhofVerbindungen() {
+        synchronized (bahnhofVerbindungen) {
+            return Collections.unmodifiableCollection(bahnhofVerbindungen.values());
+        }
+    }
+
+    public void addBahnhofVerbindung(Bahnhof bahnhof, double laenge, Line linie, Vec2d linienPos) {
+        BahnhofVerbindung verbindung = new BahnhofVerbindung(bahnhof, laenge, linie, linienPos);
+        synchronized (bahnhofVerbindungen) {
+            bahnhofVerbindungen.put(Integer.valueOf(bahnhof.id), verbindung);
+        }
+    }
+
+    public Line getLinie(Bahnhof bahnhof) {
+        BahnhofVerbindung bv = getVerbindung(bahnhof);
+
+        if (bv == null) {
+            return null;
+        }
+
+        return bv.linie;
+    }
+
+    public Set<Bahnhof> getVerbindungsBahnhoefe() {
+        Collection<BahnhofVerbindung> bvs = getBahnhofVerbindungen();
+        Set<Bahnhof> bahnhofSet = new HashSet<>();
+        for (BahnhofVerbindung bv : bvs) {
+            bahnhofSet.add(bv.getZielBahnhof());
+        }
+
+        return bahnhofSet;
+    }
+
+    public Vec2d getLinienPos(Bahnhof bahnhof) {
+        BahnhofVerbindung bv = getVerbindung(bahnhof);
+        if (bv == null) {
+            return null;
+        }
+
+        return bv.getLinienPos();
+    }
+
+    public boolean setLinienPos(Bahnhof bahnhof, Vec2d linienPos) {
+        BahnhofVerbindung bv = getVerbindung(bahnhof);
+        if (bv == null) {
+            return false;
+        }
+
+        bv.setLinienPos(linienPos);
+
+        return true;
+    }
+
+    public Bahnsteig getBahnsteigByName(String name) {
+        synchronized (bahnsteige) {
+            return bahnsteige.get(name);
+        }
+    }
+
+    public void addBahnsteig(Bahnsteig bahnsteig) {
+        synchronized (bahnsteige) {
+            this.bahnsteige.put(bahnsteig.getName(), bahnsteig);
+            this.lastBahnsteig = bahnsteig;
+        }
+        synchronized (bahnsteigListe) {
+            bahnsteigListe.add(bahnsteig);
+        }
+    }
+
+    public Bahnsteig getLastBahnsteig() {
+        synchronized (bahnsteige) {
+            return lastBahnsteig;
+        }
+    }
+
+    public void clearBahnhofVerbindungen() {
+        synchronized (bahnhofVerbindungen) {
+            this.bahnhofVerbindungen.clear();
+        }
+
+    }
+
+    public SortedMap<Integer, Bahnsteig> getBahnsteigOrderMap() {
+        SortedMap<Integer, Bahnsteig> bahnsteigMap = new TreeMap<>();
+        synchronized (bahnsteige) {
+            for (Bahnsteig bst : bahnsteige.values()) {
+                bahnsteigMap.put(Integer.valueOf(bst.getOrderId()), bst);
+            }
+        }
+
+        return bahnsteigMap;
+    }
+
+    public void clearBahnhofTeile() {
+        synchronized (bahnhofTeile) {
+            bahnhofTeile.clear();
+        }
+
+    }
 }

--- a/Plugin Gleisbelegung/src/com/gleisbelegung/lib/data/Bahnhof.java
+++ b/Plugin Gleisbelegung/src/com/gleisbelegung/lib/data/Bahnhof.java
@@ -123,6 +123,7 @@ public class Bahnhof {
             stage.close();
             Einstellungen.fenster.gleisbelegung.versteckeOrderIds();
             Einstellungen.fenster.gleisbelegung.sortiereGleise();
+            Einstellungen.fenster.stellwerksuebersicht.aktualisiereBahnhofsNamen();
         });
 
         Pane p = new Pane(name, tname,l,tf,b);

--- a/Plugin Gleisbelegung/src/com/gleisbelegung/lib/data/Bahnhof.java
+++ b/Plugin Gleisbelegung/src/com/gleisbelegung/lib/data/Bahnhof.java
@@ -13,6 +13,7 @@ import javafx.scene.text.Font;
 import javafx.stage.Stage;
 
 import javafx.scene.shape.Line;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -26,332 +27,332 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 
 public class Bahnhof {
-  /**
-   * Vebindung zwischen Bahnhof.this and BahnhofVerbindung.ziel
-   *
-   */
-  private class BahnhofVerbindung {
-    private double laenge; // dead variable
-    private Line linie;
-    private Vec2d linienPos;
-    private Bahnhof ziel;
+    /**
+     * Vebindung zwischen Bahnhof.this and BahnhofVerbindung.ziel
+     */
+    private class BahnhofVerbindung {
+        private double laenge; // dead variable
+        private Line linie;
+        private Vec2d linienPos;
+        private Bahnhof ziel;
 
-    public BahnhofVerbindung(Bahnhof bahnhof, double laenge, Line linie, Vec2d linienPos) {
-      this.laenge = laenge;
-      this.linie = linie;
-      this.linienPos = linienPos;
-      ziel = bahnhof;
+        public BahnhofVerbindung(Bahnhof bahnhof, double laenge, Line linie, Vec2d linienPos) {
+            this.laenge = laenge;
+            this.linie = linie;
+            this.linienPos = linienPos;
+            ziel = bahnhof;
+        }
+
+        public void setLinienPos(Vec2d linienPos) {
+            this.linienPos = linienPos;
+        }
+
+        public Vec2d getLinienPos() {
+            return linienPos;
+        }
+
+        public Bahnhof getStartBahnhof() {
+            return Bahnhof.this;
+        }
+
+        public Bahnhof getZielBahnhof() {
+            return ziel;
+        }
     }
 
-    public void setLinienPos(Vec2d linienPos) {
-      this.linienPos = linienPos;
+    private class BahnhofTeil implements Iterable<Bahnsteig> {
+        private LabelContainer bahnhofsLabel;
+        private List<Bahnsteig> bahnsteige;
+
+        public BahnhofTeil(LabelContainer bahnhofsLabel, List<Bahnsteig> bahnsteige) {
+            this.bahnhofsLabel = bahnhofsLabel;
+            this.bahnsteige = bahnsteige;
+
+        }
+
+        void hervorheben() {
+            for (Bahnsteig b : bahnsteige) {
+                b.hebeHervor();
+            }
+        }
+
+        public int getBahnsteigSize() {
+            return bahnsteige.size();
+        }
+
+        public Iterator<Bahnsteig> iterator() {
+            return bahnsteige.iterator();
+        }
     }
 
-    public Vec2d getLinienPos() {
-      return linienPos;
+    private int id;
+    private String name;
+    private String alternativName = "";
+    private Map<String, Bahnsteig> bahnsteige = new HashMap<>();
+    private List<Bahnsteig> bahnsteigListe = new ArrayList<>();
+    private List<BahnhofTeil> bahnhofTeile = new ArrayList<>();
+    private Map<Integer, BahnhofVerbindung> bahnhofVerbindungen = new HashMap<>();
+    private boolean sichtbar;
+    private Vec2d pos;
+    private Bahnsteig lastBahnsteig;
+
+    public Bahnhof(int id, String name) {
+        this.id = id;
+        this.name = name;
+        pos = new Vec2d(30, id * 40 + 40);
     }
 
-    public Bahnhof getStartBahnhof() {
-      return Bahnhof.this;
+    private BahnhofVerbindung getVerbindung(Bahnhof bahnhof) {
+        synchronized (bahnhofVerbindungen) {
+            return bahnhofVerbindungen.get(Integer.valueOf(bahnhof.id));
+        }
     }
 
-    public Bahnhof getZielBahnhof() {
-      return ziel;
-    }
-  }
-
-  private class BahnhofTeil implements Iterable<Bahnsteig> {
-    private LabelContainer bahnhofsLabel;
-    private List<Bahnsteig> bahnsteige;
-
-    public BahnhofTeil(LabelContainer bahnhofsLabel, List<Bahnsteig> bahnsteige) {
-      this.bahnhofsLabel = bahnhofsLabel;
-      this.bahnsteige = bahnsteige;
-
+    public int getId() {
+        return id;
     }
 
-    void hervorheben() {
-      for (Bahnsteig b : bahnsteige) {
-        b.hebeHervor();
-      }
+    public String getName() {
+        return name;
     }
 
-    public int getBahnsteigSize() {
-      return bahnsteige.size();
+    public Collection<Bahnsteig> getBahnsteige() {
+        synchronized (bahnsteigListe) {
+            return Collections.unmodifiableList(new ArrayList<>(bahnsteigListe));
+        }
     }
 
-    public Iterator<Bahnsteig> iterator() {
-      return bahnsteige.iterator();
+    public Bahnsteig getBahnsteig(int index) {
+        synchronized (bahnsteigListe) {
+            return bahnsteigListe.get(index);
+        }
     }
-  }
 
-  private int id;
-  private String name;
-  private String alternativName = "";
-  private Map<String, Bahnsteig> bahnsteige = new HashMap<>();
-  private List<Bahnsteig> bahnsteigListe = new ArrayList<>();
-  private List<BahnhofTeil> bahnhofTeile = new ArrayList<>();
-  private Map<Integer, BahnhofVerbindung> bahnhofVerbindungen = new HashMap<>();
-  private boolean sichtbar;
-  private Vec2d pos;
-  private Bahnsteig lastBahnsteig;
-
-  public Bahnhof(int id, String name) {
-    this.id = id;
-    this.name = name;
-    pos = new Vec2d(30, id * 40 + 40);
-  }
-
-  private BahnhofVerbindung getVerbindung(Bahnhof bahnhof) {
-    synchronized (bahnhofVerbindungen) {
-      return bahnhofVerbindungen.get(Integer.valueOf(bahnhof.id));
+    public int getAnzahlBahnsteige() {
+        synchronized (bahnsteige) {
+            return bahnsteige.size();
+        }
     }
-  }
 
-  public int getId() {
-    return id;
-  }
+    public boolean isSichtbar() {
+        synchronized (bahnsteige) {
+            for (Bahnsteig b : bahnsteige.values()) {
+                if (!b.isSichtbar())
+                    return false;
 
-  public String getName() {
-    return name;
-  }
-
-  public Collection<Bahnsteig> getBahnsteige() {
-    synchronized (bahnsteigListe) {
-      return Collections.unmodifiableList(new ArrayList<>(bahnsteigListe));
+            }
+        }
+        return true;
     }
-  }
 
-  public Bahnsteig getBahnsteig(int index) {
-    synchronized (bahnsteigListe) {
-      return bahnsteigListe.get(index);
+    public void setSichtbar(boolean sichtbar) {
+        synchronized (bahnsteige) {
+            for (Bahnsteig b : bahnsteige.values())
+                b.setSichtbar(sichtbar);
+        }
     }
-  }
 
-  public int getAnzahlBahnsteige() {
-    synchronized (bahnsteige) {
-      return bahnsteige.size();
+    public List<BahnhofTeil> getBahnhofTeile() {
+        synchronized (bahnhofTeile) {
+            return Collections.unmodifiableList(bahnhofTeile);
+        }
     }
-  }
 
-  public boolean isSichtbar() {
-    synchronized (bahnsteige) {
-      for (Bahnsteig b : bahnsteige.values()) {
-        if (!b.isSichtbar())
-          return false;
-
-      }
-    }
-    return true;
-  }
-
-  public void setSichtbar(boolean sichtbar) {
-    synchronized (bahnsteige) {
-      for (Bahnsteig b : bahnsteige.values())
-        b.setSichtbar(sichtbar);
-    }
-  }
-
-  public List<BahnhofTeil> getBahnhofTeile() {
-    synchronized (bahnhofTeile) {
-      return Collections.unmodifiableList(bahnhofTeile);
-    }
-  }
     public BahnhofTeil getBahnhofTeile(int index) {
         synchronized (bahnhofTeile) {
             return bahnhofTeile.get(index);
         }
     }
 
-  public void addBahnhofLabel(LabelContainer bahnhofLabel, List<Bahnsteig> bahnsteige) {
-    BahnhofTeil bt = new BahnhofTeil(bahnhofLabel, bahnsteige);
-    synchronized (bahnhofTeile) {
-      bahnhofTeile.add(bt);
+    public void addBahnhofLabel(LabelContainer bahnhofLabel, List<Bahnsteig> bahnsteige) {
+        BahnhofTeil bt = new BahnhofTeil(bahnhofLabel, bahnsteige);
+        synchronized (bahnhofTeile) {
+            bahnhofTeile.add(bt);
+        }
+
+        bahnhofLabel.getLabel().setOnMouseClicked(e -> {
+            if (e.getButton() == MouseButton.PRIMARY) {
+                bt.hervorheben();
+                System.out.println(bt.getBahnsteigSize());
+            } else if (e.getButton() == MouseButton.SECONDARY) {
+                einstellungen(bt);
+            }
+        });
     }
 
-    bahnhofLabel.getLabel().setOnMouseClicked(e -> {
-      if (e.getButton() == MouseButton.PRIMARY) {
-        bt.hervorheben();
-        System.out.println(bt.getBahnsteigSize());
-      } else if (e.getButton() == MouseButton.SECONDARY) {
-        einstellungen(bt);
-      }
-    });
-  }
-
-  public String getAlternativName() {
-    return alternativName;
-  }
-
-  public void einstellungen(BahnhofTeil bt) {
-    Einstellungen.fenster.gleisbelegung.zeigeOrderIds();
-    Stage stage = new Stage();
-
-    Label name = new Label("Name:");
-    name.setStyle("-fx-text-fill: white;");
-    name.setFont(Font.font(Einstellungen.schriftgroesse));
-    name.setTranslateY(25);
-    name.setTranslateX(25);
-
-    TextField tname = new TextField(alternativName);
-    tname.setFont(Font.font(Einstellungen.schriftgroesse - 3));
-    tname.setTranslateX(25);
-    tname.setTranslateY(60);
-
-    Label l = new Label("Reihenfolge festlegen:");
-    l.setStyle("-fx-text-fill: white;");
-    l.setFont(Font.font(Einstellungen.schriftgroesse));
-    l.setTranslateX(25);
-    l.setTranslateY(95);
-
-    TextField tf = new TextField(String.valueOf(bahnsteige.get(0).getOrderId() + 1));
-    tf.setFont(Font.font(Einstellungen.schriftgroesse - 3));
-    tf.setTranslateX(25);
-    tf.setTranslateY(130);
-
-    Button b = new Button("Speichern");
-    b.setFont(Font.font(Einstellungen.schriftgroesse));
-    b.setTranslateX(25);
-    b.setTranslateY(190);
-    b.setOnAction(e -> {
-      int order = Integer.parseInt(tf.getText()) - 1;
-      for (Bahnsteig ba : bt) {
-        ba.setOrderId(order);
-        alternativName = tname.getText();
-      }
-
-      stage.close();
-      Einstellungen.fenster.gleisbelegung.versteckeOrderIds();
-      Einstellungen.fenster.gleisbelegung.sortiereGleise();
-      Einstellungen.fenster.stellwerksuebersicht.aktualisiereBahnhofsNamen();
-    });
-
-    Pane p = new Pane(name, tname, l, tf, b);
-    p.setStyle("-fx-background-color: #303030;");
-    p.setMinSize(500, 200);
-    p.setMaxSize(500, 200);
-
-    Scene scene = new Scene(p, 300, 250);
-
-    stage.setScene(scene);
-    stage.show();
-    stage.setAlwaysOnTop(true);
-
-    stage.setOnCloseRequest(e -> {
-      Einstellungen.fenster.gleisbelegung.versteckeOrderIds();
-    });
-  }
-
-  @Override
-  public String toString() {
-    return "Bahnhof{" + "id=" + id + ", name='" + name + '\'' + ", bahnsteige=" + bahnsteige + '}';
-  }
-
-  public Vec2d getPos() {
-    return pos;
-  }
-
-  public void setPos(Vec2d pos) {
-    this.pos = pos;
-  }
-
-  public Collection<BahnhofVerbindung> getBahnhofVerbindungen() {
-    synchronized (bahnhofVerbindungen) {
-      return Collections.unmodifiableCollection(bahnhofVerbindungen.values());
-    }
-  }
-
-  public void addBahnhofVerbindung(Bahnhof bahnhof, double laenge, Line linie, Vec2d linienPos) {
-    BahnhofVerbindung verbindung = new BahnhofVerbindung(bahnhof, laenge, linie, linienPos);
-    synchronized (bahnhofVerbindungen) {
-      bahnhofVerbindungen.put(Integer.valueOf(bahnhof.id), verbindung);
-    }
-  }
-
-  public Line getLinie(Bahnhof bahnhof) {
-    BahnhofVerbindung bv = getVerbindung(bahnhof);
-
-    if (bv == null) {
-      return null;
+    public String getAlternativName() {
+        return alternativName;
     }
 
-    return bv.linie;
-  }
+    public void einstellungen(BahnhofTeil bt) {
+        Einstellungen.fenster.gleisbelegung.zeigeOrderIds();
+        Stage stage = new Stage();
 
-  public Set<Bahnhof> getVerbindungsBahnhoefe() {
-    Collection<BahnhofVerbindung> bvs = getBahnhofVerbindungen();
-    Set<Bahnhof> bahnhofSet = new HashSet<>();
-    for (BahnhofVerbindung bv : bvs) {
-      bahnhofSet.add(bv.getZielBahnhof());
+        Label name = new Label("Name:");
+        name.setStyle("-fx-text-fill: white;");
+        name.setFont(Font.font(Einstellungen.schriftgroesse));
+        name.setTranslateY(25);
+        name.setTranslateX(25);
+
+        TextField tname = new TextField(alternativName);
+        tname.setFont(Font.font(Einstellungen.schriftgroesse - 3));
+        tname.setTranslateX(25);
+        tname.setTranslateY(60);
+
+        Label l = new Label("Reihenfolge festlegen:");
+        l.setStyle("-fx-text-fill: white;");
+        l.setFont(Font.font(Einstellungen.schriftgroesse));
+        l.setTranslateX(25);
+        l.setTranslateY(95);
+
+        TextField tf = new TextField(String.valueOf(bahnsteige.entrySet().iterator().next().getValue().getOrderId() + 1));
+        tf.setFont(Font.font(Einstellungen.schriftgroesse - 3));
+        tf.setTranslateX(25);
+        tf.setTranslateY(130);
+
+        Button b = new Button("Speichern");
+        b.setFont(Font.font(Einstellungen.schriftgroesse));
+        b.setTranslateX(25);
+        b.setTranslateY(190);
+        b.setOnAction(e -> {
+            int order = Integer.parseInt(tf.getText()) - 1;
+            for (Bahnsteig ba : bt) {
+                ba.setOrderId(order);
+                alternativName = tname.getText();
+            }
+
+            stage.close();
+            Einstellungen.fenster.gleisbelegung.versteckeOrderIds();
+            Einstellungen.fenster.gleisbelegung.sortiereGleise();
+            Einstellungen.fenster.stellwerksuebersicht.aktualisiereBahnhofsNamen();
+        });
+
+        Pane p = new Pane(name, tname, l, tf, b);
+        p.setStyle("-fx-background-color: #303030;");
+        p.setMinSize(500, 200);
+        p.setMaxSize(500, 200);
+
+        Scene scene = new Scene(p, 300, 250);
+
+        stage.setScene(scene);
+        stage.show();
+        stage.setAlwaysOnTop(true);
+
+        stage.setOnCloseRequest(e -> {
+            Einstellungen.fenster.gleisbelegung.versteckeOrderIds();
+        });
     }
 
-    return bahnhofSet;
-  }
-
-  public Vec2d getLinienPos(Bahnhof bahnhof) {
-    BahnhofVerbindung bv = getVerbindung(bahnhof);
-    if (bv == null) {
-      return null;
+    @Override
+    public String toString() {
+        return "Bahnhof{" + "id=" + id + ", name='" + name + '\'' + ", bahnsteige=" + bahnsteige + '}';
     }
 
-    return bv.getLinienPos();
-  }
-
-  public boolean setLinienPos(Bahnhof bahnhof, Vec2d linienPos) {
-    BahnhofVerbindung bv = getVerbindung(bahnhof);
-    if (bv == null) {
-      return false;
+    public Vec2d getPos() {
+        return pos;
     }
 
-    bv.setLinienPos(linienPos);
-
-    return true;
-  }
-
-  public Bahnsteig getBahnsteigByName(String name) {
-    synchronized (bahnsteige) {
-      return bahnsteige.get(name);
-    }
-  }
-
-  public void addBahnsteig(Bahnsteig bahnsteig) {
-    synchronized (bahnsteige) {
-      this.bahnsteige.put(bahnsteig.getName(), bahnsteig);
-      this.lastBahnsteig = bahnsteig;
-    }
-    synchronized (bahnsteigListe) {
-      bahnsteigListe.add(bahnsteig);
-    }
-  }
-
-  public Bahnsteig getLastBahnsteig() {
-    synchronized (bahnsteige) {
-      return lastBahnsteig;
-    }
-  }
-
-  public void clearBahnhofVerbindungen() {
-    synchronized (bahnhofVerbindungen) {
-      this.bahnhofVerbindungen.clear();
+    public void setPos(Vec2d pos) {
+        this.pos = pos;
     }
 
-  }
-
-  public SortedMap<Integer, Bahnsteig> getBahnsteigOrderMap() {
-    SortedMap<Integer, Bahnsteig> bahnsteigMap = new TreeMap<>();
-    synchronized (bahnsteige) {
-      for (Bahnsteig bst : bahnsteige.values()) {
-        bahnsteigMap.put(Integer.valueOf(bst.getOrderId()), bst);
-      }
+    public Collection<BahnhofVerbindung> getBahnhofVerbindungen() {
+        synchronized (bahnhofVerbindungen) {
+            return Collections.unmodifiableCollection(bahnhofVerbindungen.values());
+        }
     }
 
-    return bahnsteigMap;
-  }
-
-  public void clearBahnhofTeile() {
-    synchronized (bahnhofTeile) {
-      bahnhofTeile.clear();
+    public void addBahnhofVerbindung(Bahnhof bahnhof, double laenge, Line linie, Vec2d linienPos) {
+        BahnhofVerbindung verbindung = new BahnhofVerbindung(bahnhof, laenge, linie, linienPos);
+        synchronized (bahnhofVerbindungen) {
+            bahnhofVerbindungen.put(Integer.valueOf(bahnhof.id), verbindung);
+        }
     }
 
-  }
+    public Line getLinie(Bahnhof bahnhof) {
+        BahnhofVerbindung bv = getVerbindung(bahnhof);
+
+        if (bv == null) {
+            return null;
+        }
+
+        return bv.linie;
+    }
+
+    public Set<Bahnhof> getVerbindungsBahnhoefe() {
+        Collection<BahnhofVerbindung> bvs = getBahnhofVerbindungen();
+        Set<Bahnhof> bahnhofSet = new HashSet<>();
+        for (BahnhofVerbindung bv : bvs) {
+            bahnhofSet.add(bv.getZielBahnhof());
+        }
+
+        return bahnhofSet;
+    }
+
+    public Vec2d getLinienPos(Bahnhof bahnhof) {
+        BahnhofVerbindung bv = getVerbindung(bahnhof);
+        if (bv == null) {
+            return null;
+        }
+
+        return bv.getLinienPos();
+    }
+
+    public boolean setLinienPos(Bahnhof bahnhof, Vec2d linienPos) {
+        BahnhofVerbindung bv = getVerbindung(bahnhof);
+        if (bv == null) {
+            return false;
+        }
+
+        bv.setLinienPos(linienPos);
+
+        return true;
+    }
+
+    public Bahnsteig getBahnsteigByName(String name) {
+        synchronized (bahnsteige) {
+            return bahnsteige.get(name);
+        }
+    }
+
+    public void addBahnsteig(Bahnsteig bahnsteig) {
+        synchronized (bahnsteige) {
+            this.bahnsteige.put(bahnsteig.getName(), bahnsteig);
+            this.lastBahnsteig = bahnsteig;
+        }
+        synchronized (bahnsteigListe) {
+            bahnsteigListe.add(bahnsteig);
+        }
+    }
+
+    public Bahnsteig getLastBahnsteig() {
+        synchronized (bahnsteige) {
+            return lastBahnsteig;
+        }
+    }
+
+    public void clearBahnhofVerbindungen() {
+        synchronized (bahnhofVerbindungen) {
+            this.bahnhofVerbindungen.clear();
+        }
+
+    }
+
+    public SortedMap<Integer, Bahnsteig> getBahnsteigOrderMap() {
+        SortedMap<Integer, Bahnsteig> bahnsteigMap = new TreeMap<>();
+        synchronized (bahnsteige) {
+            for (Bahnsteig bst : bahnsteige.values()) {
+                bahnsteigMap.put(Integer.valueOf(bst.getOrderId()), bst);
+            }
+        }
+
+        return bahnsteigMap;
+    }
+
+    public void clearBahnhofTeile() {
+        synchronized (bahnhofTeile) {
+            bahnhofTeile.clear();
+        }
+
+    }
 }

--- a/Plugin Gleisbelegung/src/com/gleisbelegung/lib/data/Bahnhof.java
+++ b/Plugin Gleisbelegung/src/com/gleisbelegung/lib/data/Bahnhof.java
@@ -14,223 +14,339 @@ import javafx.stage.Stage;
 
 import javafx.scene.shape.Line;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.TreeMap;
 
 public class Bahnhof {
-    private int id;
-    private String name;
-    private String alternativName = "";
-    private ArrayList<Bahnsteig> bahnsteige;
-    private ArrayList<BahnhofTeil> bahnhofTeile;
-    private ArrayList<BahnhofVerbindung> bahnhofVerbindungen;
-    private boolean sichtbar;
-    private Vec2d pos;
+  /**
+   * Vebindung zwischen Bahnhof.this and BahnhofVerbindung.ziel
+   *
+   */
+  private class BahnhofVerbindung {
+    private double laenge; // dead variable
+    private Line linie;
+    private Vec2d linienPos;
+    private Bahnhof ziel;
 
-    public Bahnhof(int id, String name){
-        this.id = id;
-        this.name = name;
-        this.bahnsteige = new ArrayList<>();
-        this.bahnhofTeile = new ArrayList<>();
-        this.bahnhofVerbindungen = new ArrayList<>();
-        pos = new Vec2d(30, id*40 + 40);
+    public BahnhofVerbindung(Bahnhof bahnhof, double laenge, Line linie, Vec2d linienPos) {
+      this.laenge = laenge;
+      this.linie = linie;
+      this.linienPos = linienPos;
+      ziel = bahnhof;
     }
 
-    public int getId(){
-        return id;
-    }
-    public String getName() {
-        return name;
-    }
-    public ArrayList<Bahnsteig> getBahnsteige() {
-        return bahnsteige;
-    }
-    public Bahnsteig getBahnsteig(int index){
-        return bahnsteige.get(index);
-    }
-    public int getAnzahlBahnsteige(){
-        return bahnsteige.size();
+    public void setLinienPos(Vec2d linienPos) {
+      this.linienPos = linienPos;
     }
 
-    public boolean isSichtbar() {
-        for (Bahnsteig b : bahnsteige) {
-            if (!b.isSichtbar())
-                return false;
-
-        }
-        return true;
+    public Vec2d getLinienPos() {
+      return linienPos;
     }
 
-    public void setSichtbar(boolean sichtbar) {
-        for (Bahnsteig b : bahnsteige)
-            b.setSichtbar(sichtbar);
+    public Bahnhof getStartBahnhof() {
+      return Bahnhof.this;
     }
 
-    public ArrayList<BahnhofTeil> getBahnhofTeile() {
-        return bahnhofTeile;
+    public Bahnhof getZielBahnhof() {
+      return ziel;
     }
-    public void addBahnhofLabel(LabelContainer bahnhofLabel, ArrayList<Bahnsteig> bahnsteige) {
-        BahnhofTeil bt = new BahnhofTeil(bahnhofLabel, bahnsteige);
-        bahnhofTeile.add(bt);
+  }
 
-        bahnhofLabel.getLabel().setOnMouseClicked(e -> {
-            if(e.getButton() == MouseButton.PRIMARY){
-                hervorheben(bt);
-                System.out.println(bt.bahnsteige.size());
-            } else if(e.getButton() == MouseButton.SECONDARY) {
-                einstellungen(bt);
-            }
-        });
+  private class BahnhofTeil implements Iterable<Bahnsteig> {
+    private LabelContainer bahnhofsLabel;
+    private List<Bahnsteig> bahnsteige;
+
+    public BahnhofTeil(LabelContainer bahnhofsLabel, List<Bahnsteig> bahnsteige) {
+      this.bahnhofsLabel = bahnhofsLabel;
+      this.bahnsteige = bahnsteige;
+
     }
 
-    public String getAlternativName() { return alternativName; }
-
-    private void einstellungen(BahnhofTeil bt){
-        Einstellungen.fenster.gleisbelegung.zeigeOrderIds();
-        Stage stage = new Stage();
-
-        Label name = new Label("Name:");
-        name.setStyle("-fx-text-fill: white;");
-        name.setFont(Font.font(Einstellungen.schriftgroesse));
-        name.setTranslateY(25);
-        name.setTranslateX(25);
-
-        TextField tname = new TextField(alternativName);
-        tname.setFont(Font.font(Einstellungen.schriftgroesse-3));
-        tname.setTranslateX(25);
-        tname.setTranslateY(60);
-
-        Label l = new Label("Reihenfolge festlegen:");
-        l.setStyle("-fx-text-fill: white;");
-        l.setFont(Font.font(Einstellungen.schriftgroesse));
-        l.setTranslateX(25);
-        l.setTranslateY(95);
-
-        TextField tf = new TextField(String.valueOf(bahnsteige.get(0).getOrderId()+1));
-        tf.setFont(Font.font(Einstellungen.schriftgroesse-3));
-        tf.setTranslateX(25);
-        tf.setTranslateY(130);
-
-        Button b = new Button("Speichern");
-        b.setFont(Font.font(Einstellungen.schriftgroesse));
-        b.setTranslateX(25);
-        b.setTranslateY(190);
-        b.setOnAction(e -> {
-            int order = Integer.parseInt(tf.getText())-1;
-            for(Bahnsteig ba : bt.bahnsteige){
-                ba.setOrderId(order);
-                alternativName = tname.getText();
-            }
-
-            stage.close();
-            Einstellungen.fenster.gleisbelegung.versteckeOrderIds();
-            Einstellungen.fenster.gleisbelegung.sortiereGleise();
-            Einstellungen.fenster.stellwerksuebersicht.aktualisiereBahnhofsNamen();
-        });
-
-        Pane p = new Pane(name, tname,l,tf,b);
-        p.setStyle("-fx-background-color: #303030;");
-        p.setMinSize(500,200);
-        p.setMaxSize(500, 200);
-
-        Scene scene = new Scene(p, 300,250);
-
-        stage.setScene(scene);
-        stage.show();
-        stage.setAlwaysOnTop(true);
-
-        stage.setOnCloseRequest(e -> {
-            Einstellungen.fenster.gleisbelegung.versteckeOrderIds();
-        });
+    void hervorheben() {
+      for (Bahnsteig b : bahnsteige) {
+        b.hebeHervor();
+      }
     }
 
-    private void hervorheben(BahnhofTeil bt){
-        for(Bahnsteig b: bt.bahnsteige){
-            b.hebeHervor();
-        }
+    public int getBahnsteigSize() {
+      return bahnsteige.size();
     }
 
-    @Override
-    public String toString() {
-        return "Bahnhof{" +
-                "id=" + id +
-                ", name='" + name + '\'' +
-                ", bahnsteige=" + bahnsteige +
-                '}';
+    public Iterator<Bahnsteig> iterator() {
+      return bahnsteige.iterator();
+    }
+  }
+
+  private int id;
+  private String name;
+  private String alternativName = "";
+  private Map<String, Bahnsteig> bahnsteige = new HashMap<>();
+  private List<Bahnsteig> bahnsteigListe = new ArrayList<>();
+  private List<BahnhofTeil> bahnhofTeile = new ArrayList<>();
+  private Map<Integer, BahnhofVerbindung> bahnhofVerbindungen = new HashMap<>();
+  private boolean sichtbar;
+  private Vec2d pos;
+  private Bahnsteig lastBahnsteig;
+
+  public Bahnhof(int id, String name) {
+    this.id = id;
+    this.name = name;
+    pos = new Vec2d(30, id * 40 + 40);
+  }
+
+  private BahnhofVerbindung getVerbindung(Bahnhof bahnhof) {
+    synchronized (bahnhofVerbindungen) {
+      return bahnhofVerbindungen.get(Integer.valueOf(bahnhof.id));
+    }
+  }
+
+  public int getId() {
+    return id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public Collection<Bahnsteig> getBahnsteige() {
+    synchronized (bahnsteigListe) {
+      return Collections.unmodifiableList(new ArrayList<>(bahnsteigListe));
+    }
+  }
+
+  public Bahnsteig getBahnsteig(int index) {
+    synchronized (bahnsteigListe) {
+      return bahnsteigListe.get(index);
+    }
+  }
+
+  public int getAnzahlBahnsteige() {
+    synchronized (bahnsteige) {
+      return bahnsteige.size();
+    }
+  }
+
+  public boolean isSichtbar() {
+    synchronized (bahnsteige) {
+      for (Bahnsteig b : bahnsteige.values()) {
+        if (!b.isSichtbar())
+          return false;
+
+      }
+    }
+    return true;
+  }
+
+  public void setSichtbar(boolean sichtbar) {
+    synchronized (bahnsteige) {
+      for (Bahnsteig b : bahnsteige.values())
+        b.setSichtbar(sichtbar);
+    }
+  }
+
+  public List<BahnhofTeil> getBahnhofTeile() {
+    synchronized (bahnhofTeile) {
+      return Collections.unmodifiableList(bahnhofTeile);
+    }
+  }
+
+  public void addBahnhofLabel(LabelContainer bahnhofLabel, List<Bahnsteig> bahnsteige) {
+    BahnhofTeil bt = new BahnhofTeil(bahnhofLabel, bahnsteige);
+    synchronized (bahnhofTeile) {
+      bahnhofTeile.add(bt);
     }
 
-    public Vec2d getPos() {
-        return pos;
+    bahnhofLabel.getLabel().setOnMouseClicked(e -> {
+      if (e.getButton() == MouseButton.PRIMARY) {
+        bt.hervorheben();
+        System.out.println(bt.getBahnsteigSize());
+      } else if (e.getButton() == MouseButton.SECONDARY) {
+        einstellungen(bt);
+      }
+    });
+  }
+
+  public String getAlternativName() {
+    return alternativName;
+  }
+
+  private void einstellungen(BahnhofTeil bt) {
+    Einstellungen.fenster.gleisbelegung.zeigeOrderIds();
+    Stage stage = new Stage();
+
+    Label name = new Label("Name:");
+    name.setStyle("-fx-text-fill: white;");
+    name.setFont(Font.font(Einstellungen.schriftgroesse));
+    name.setTranslateY(25);
+    name.setTranslateX(25);
+
+    TextField tname = new TextField(alternativName);
+    tname.setFont(Font.font(Einstellungen.schriftgroesse - 3));
+    tname.setTranslateX(25);
+    tname.setTranslateY(60);
+
+    Label l = new Label("Reihenfolge festlegen:");
+    l.setStyle("-fx-text-fill: white;");
+    l.setFont(Font.font(Einstellungen.schriftgroesse));
+    l.setTranslateX(25);
+    l.setTranslateY(95);
+
+    TextField tf = new TextField(String.valueOf(bahnsteige.get(0).getOrderId() + 1));
+    tf.setFont(Font.font(Einstellungen.schriftgroesse - 3));
+    tf.setTranslateX(25);
+    tf.setTranslateY(130);
+
+    Button b = new Button("Speichern");
+    b.setFont(Font.font(Einstellungen.schriftgroesse));
+    b.setTranslateX(25);
+    b.setTranslateY(190);
+    b.setOnAction(e -> {
+      int order = Integer.parseInt(tf.getText()) - 1;
+      for (Bahnsteig ba : bt) {
+        ba.setOrderId(order);
+        alternativName = tname.getText();
+      }
+
+      stage.close();
+      Einstellungen.fenster.gleisbelegung.versteckeOrderIds();
+      Einstellungen.fenster.gleisbelegung.sortiereGleise();
+      Einstellungen.fenster.stellwerksuebersicht.aktualisiereBahnhofsNamen();
+    });
+
+    Pane p = new Pane(name, tname, l, tf, b);
+    p.setStyle("-fx-background-color: #303030;");
+    p.setMinSize(500, 200);
+    p.setMaxSize(500, 200);
+
+    Scene scene = new Scene(p, 300, 250);
+
+    stage.setScene(scene);
+    stage.show();
+    stage.setAlwaysOnTop(true);
+
+    stage.setOnCloseRequest(e -> {
+      Einstellungen.fenster.gleisbelegung.versteckeOrderIds();
+    });
+  }
+
+  @Override
+  public String toString() {
+    return "Bahnhof{" + "id=" + id + ", name='" + name + '\'' + ", bahnsteige=" + bahnsteige + '}';
+  }
+
+  public Vec2d getPos() {
+    return pos;
+  }
+
+  public void setPos(Vec2d pos) {
+    this.pos = pos;
+  }
+
+  public Collection<BahnhofVerbindung> getBahnhofVerbindungen() {
+    synchronized (bahnhofVerbindungen) {
+      return Collections.unmodifiableCollection(bahnhofVerbindungen.values());
     }
-    public void setPos(Vec2d pos) {
-        this.pos = pos;
+  }
+
+  public void addBahnhofVerbindung(Bahnhof bahnhof, double laenge, Line linie, Vec2d linienPos) {
+    BahnhofVerbindung verbindung = new BahnhofVerbindung(bahnhof, laenge, linie, linienPos);
+    synchronized (bahnhofVerbindungen) {
+      bahnhofVerbindungen.put(Integer.valueOf(bahnhof.id), verbindung);
+    }
+  }
+
+  public Line getLinie(Bahnhof bahnhof) {
+    BahnhofVerbindung bv = getVerbindung(bahnhof);
+
+    if (bv == null) {
+      return null;
     }
 
-    public ArrayList<BahnhofVerbindung> getBahnhofVerbindungen() {
-        return bahnhofVerbindungen;
-    }
-    public void addBahnhofVerbindung(Bahnhof bahnhof, double laenge, Line linie, Vec2d linienPos){
-        bahnhofVerbindungen.add(new BahnhofVerbindung(bahnhof, laenge, linie, linienPos));
-    }
-    public double getVerbindungsLaenge(Bahnhof bahnhof){
-        for(BahnhofVerbindung bv : bahnhofVerbindungen){
-            if(bv.bahnhof.getId() == bahnhof.getId()){
-                return bv.laenge;
-            }
-        }
-        return -1;
-    }
-    public Line getLinie(Bahnhof bahnhof){
-        for(BahnhofVerbindung bv : bahnhofVerbindungen){
-            if(bv.bahnhof.getId() == bahnhof.getId()){
-                return bv.linie;
-            }
-        }
-        return null;
-    }
-    public ArrayList<Bahnhof> getVerbindungsBahnhoefe(){
-        ArrayList<Bahnhof> bahnhoefe = new ArrayList<>();
-        for(BahnhofVerbindung bv : bahnhofVerbindungen){
-            bahnhoefe.add(bv.bahnhof);
-        }
-        return bahnhoefe;
-    }
-    public Vec2d getLinienPos(Bahnhof bahnhof){
-        for(BahnhofVerbindung bv : bahnhofVerbindungen){
-            if(bv.bahnhof.getId() == bahnhof.getId()){
-                return bv.linienPos;
-            }
-        }
-        return null;
-    }
-    public void setLinienPos(Bahnhof bahnhof, Vec2d linienPos){
-        for(BahnhofVerbindung bv : bahnhofVerbindungen){
-            if(bv.bahnhof.getId() == bahnhof.getId()){
-                bv.linienPos = linienPos;
-                break;
-            }
-        }
-    }
-}
+    return bv.linie;
+  }
 
-class BahnhofTeil{
-    LabelContainer bahnhofsLabel;
-    ArrayList<Bahnsteig> bahnsteige;
-
-    public BahnhofTeil(LabelContainer bahnhofsLabel, ArrayList<Bahnsteig> bahnsteige){
-        this.bahnhofsLabel = bahnhofsLabel;
-        this.bahnsteige = bahnsteige;
+  public Set<Bahnhof> getVerbindungsBahnhoefe() {
+    Collection<BahnhofVerbindung> bvs = getBahnhofVerbindungen();
+    Set<Bahnhof> bahnhofSet = new HashSet<>();
+    for (BahnhofVerbindung bv : bvs) {
+      bahnhofSet.add(bv.getZielBahnhof());
     }
-}
 
-class BahnhofVerbindung{
-    Bahnhof bahnhof;
-    double laenge;
-    Line linie;
-    Vec2d linienPos;
+    return bahnhofSet;
+  }
 
-    public BahnhofVerbindung(Bahnhof bahnhof, double laenge, Line linie, Vec2d linienPos){
-        this.bahnhof = bahnhof;
-        this.laenge = laenge;
-        this.linie = linie;
-        this.linienPos = linienPos;
+  public Vec2d getLinienPos(Bahnhof bahnhof) {
+    BahnhofVerbindung bv = getVerbindung(bahnhof);
+    if (bv == null) {
+      return null;
     }
+
+    return bv.getLinienPos();
+  }
+
+  public boolean setLinienPos(Bahnhof bahnhof, Vec2d linienPos) {
+    BahnhofVerbindung bv = getVerbindung(bahnhof);
+    if (bv == null) {
+      return false;
+    }
+
+    bv.setLinienPos(linienPos);
+
+    return true;
+  }
+
+  public Bahnsteig getBahnsteigByName(String name) {
+    synchronized (bahnsteige) {
+      return bahnsteige.get(name);
+    }
+  }
+
+  public void addBahnsteig(Bahnsteig bahnsteig) {
+    synchronized (bahnsteige) {
+      this.bahnsteige.put(bahnsteig.getName(), bahnsteig);
+      this.lastBahnsteig = bahnsteig;
+    }
+    synchronized (bahnsteigListe) {
+      bahnsteigListe.add(bahnsteig);
+    }
+  }
+
+  public Bahnsteig getLastBahnsteig() {
+    synchronized (bahnsteige) {
+      return lastBahnsteig;
+    }
+  }
+
+  public void clearBahnhofVerbindungen() {
+    synchronized (bahnhofVerbindungen) {
+      this.bahnhofVerbindungen.clear();
+    }
+
+  }
+
+  public SortedMap<Integer, Bahnsteig> getBahnsteigOrderMap() {
+    SortedMap<Integer, Bahnsteig> bahnsteigMap = new TreeMap<>();
+    synchronized (bahnsteige) {
+      for (Bahnsteig bst : bahnsteige.values()) {
+        bahnsteigMap.put(Integer.valueOf(bst.getOrderId()), bst);
+      }
+    }
+
+    return bahnsteigMap;
+  }
+
+  public void clearBahnhofTeile() {
+    synchronized (bahnhofTeile) {
+      bahnhofTeile.clear();
+    }
+
+  }
 }

--- a/Plugin Gleisbelegung/src/com/gleisbelegung/lib/data/Bahnhof.java
+++ b/Plugin Gleisbelegung/src/com/gleisbelegung/lib/data/Bahnhof.java
@@ -13,7 +13,6 @@ import javafx.scene.text.Font;
 import javafx.stage.Stage;
 
 import javafx.scene.shape.Line;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -27,326 +26,327 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 
 public class Bahnhof {
-    /**
-     * Vebindung zwischen Bahnhof.this and BahnhofVerbindung.ziel
-     */
-    private class BahnhofVerbindung {
-        private double laenge; // dead variable
-        private Line linie;
-        private Vec2d linienPos;
-        private Bahnhof ziel;
+  /**
+   * Vebindung zwischen Bahnhof.this and BahnhofVerbindung.ziel
+   *
+   */
+  private class BahnhofVerbindung {
+    private double laenge; // dead variable
+    private Line linie;
+    private Vec2d linienPos;
+    private Bahnhof ziel;
 
-        public BahnhofVerbindung(Bahnhof bahnhof, double laenge, Line linie, Vec2d linienPos) {
-            this.laenge = laenge;
-            this.linie = linie;
-            this.linienPos = linienPos;
-            ziel = bahnhof;
-        }
-
-        public void setLinienPos(Vec2d linienPos) {
-            this.linienPos = linienPos;
-        }
-
-        public Vec2d getLinienPos() {
-            return linienPos;
-        }
-
-        public Bahnhof getStartBahnhof() {
-            return Bahnhof.this;
-        }
-
-        public Bahnhof getZielBahnhof() {
-            return ziel;
-        }
+    public BahnhofVerbindung(Bahnhof bahnhof, double laenge, Line linie, Vec2d linienPos) {
+      this.laenge = laenge;
+      this.linie = linie;
+      this.linienPos = linienPos;
+      ziel = bahnhof;
     }
 
-    private class BahnhofTeil implements Iterable<Bahnsteig> {
-        private LabelContainer bahnhofsLabel;
-        private List<Bahnsteig> bahnsteige;
-
-        public BahnhofTeil(LabelContainer bahnhofsLabel, List<Bahnsteig> bahnsteige) {
-            this.bahnhofsLabel = bahnhofsLabel;
-            this.bahnsteige = bahnsteige;
-
-        }
-
-        void hervorheben() {
-            for (Bahnsteig b : bahnsteige) {
-                b.hebeHervor();
-            }
-        }
-
-        public int getBahnsteigSize() {
-            return bahnsteige.size();
-        }
-
-        public Iterator<Bahnsteig> iterator() {
-            return bahnsteige.iterator();
-        }
+    public void setLinienPos(Vec2d linienPos) {
+      this.linienPos = linienPos;
     }
 
-    private int id;
-    private String name;
-    private String alternativName = "";
-    private Map<String, Bahnsteig> bahnsteige = new HashMap<>();
-    private List<Bahnsteig> bahnsteigListe = new ArrayList<>();
-    private List<BahnhofTeil> bahnhofTeile = new ArrayList<>();
-    private Map<Integer, BahnhofVerbindung> bahnhofVerbindungen = new HashMap<>();
-    private boolean sichtbar;
-    private Vec2d pos;
-    private Bahnsteig lastBahnsteig;
-
-    public Bahnhof(int id, String name) {
-        this.id = id;
-        this.name = name;
-        pos = new Vec2d(30, id * 40 + 40);
+    public Vec2d getLinienPos() {
+      return linienPos;
     }
 
-    private BahnhofVerbindung getVerbindung(Bahnhof bahnhof) {
-        synchronized (bahnhofVerbindungen) {
-            return bahnhofVerbindungen.get(Integer.valueOf(bahnhof.id));
-        }
+    public Bahnhof getStartBahnhof() {
+      return Bahnhof.this;
     }
 
-    public int getId() {
-        return id;
+    public Bahnhof getZielBahnhof() {
+      return ziel;
     }
+  }
 
-    public String getName() {
-        return name;
-    }
+  private class BahnhofTeil implements Iterable<Bahnsteig> {
+    private LabelContainer bahnhofsLabel;
+    private List<Bahnsteig> bahnsteige;
 
-    public Collection<Bahnsteig> getBahnsteige() {
-        synchronized (bahnsteigListe) {
-            return Collections.unmodifiableList(new ArrayList<>(bahnsteigListe));
-        }
-    }
-
-    public Bahnsteig getBahnsteig(int index) {
-        synchronized (bahnsteigListe) {
-            return bahnsteigListe.get(index);
-        }
-    }
-
-    public int getAnzahlBahnsteige() {
-        synchronized (bahnsteige) {
-            return bahnsteige.size();
-        }
-    }
-
-    public boolean isSichtbar() {
-        synchronized (bahnsteige) {
-            for (Bahnsteig b : bahnsteige.values()) {
-                if (!b.isSichtbar())
-                    return false;
-
-            }
-        }
-        return true;
-    }
-
-    public void setSichtbar(boolean sichtbar) {
-        synchronized (bahnsteige) {
-            for (Bahnsteig b : bahnsteige.values())
-                b.setSichtbar(sichtbar);
-        }
-    }
-
-    public List<BahnhofTeil> getBahnhofTeile() {
-        synchronized (bahnhofTeile) {
-            return Collections.unmodifiableList(bahnhofTeile);
-        }
-    }
-
-    public void addBahnhofLabel(LabelContainer bahnhofLabel, List<Bahnsteig> bahnsteige) {
-        BahnhofTeil bt = new BahnhofTeil(bahnhofLabel, bahnsteige);
-        synchronized (bahnhofTeile) {
-            bahnhofTeile.add(bt);
-        }
-
-        bahnhofLabel.getLabel().setOnMouseClicked(e -> {
-            if (e.getButton() == MouseButton.PRIMARY) {
-                bt.hervorheben();
-                System.out.println(bt.getBahnsteigSize());
-            } else if (e.getButton() == MouseButton.SECONDARY) {
-                einstellungen(bt);
-            }
-        });
-    }
-
-    public String getAlternativName() {
-        return alternativName;
-    }
-
-    private void einstellungen(BahnhofTeil bt) {
-        Einstellungen.fenster.gleisbelegung.zeigeOrderIds();
-        Stage stage = new Stage();
-
-        Label name = new Label("Name:");
-        name.setStyle("-fx-text-fill: white;");
-        name.setFont(Font.font(Einstellungen.schriftgroesse));
-        name.setTranslateY(25);
-        name.setTranslateX(25);
-
-        TextField tname = new TextField(alternativName);
-        tname.setFont(Font.font(Einstellungen.schriftgroesse - 3));
-        tname.setTranslateX(25);
-        tname.setTranslateY(60);
-
-        Label l = new Label("Reihenfolge festlegen:");
-        l.setStyle("-fx-text-fill: white;");
-        l.setFont(Font.font(Einstellungen.schriftgroesse));
-        l.setTranslateX(25);
-        l.setTranslateY(95);
-
-        TextField tf = new TextField(String.valueOf(bahnsteige.get(0).getOrderId() + 1));
-        tf.setFont(Font.font(Einstellungen.schriftgroesse - 3));
-        tf.setTranslateX(25);
-        tf.setTranslateY(130);
-
-        Button b = new Button("Speichern");
-        b.setFont(Font.font(Einstellungen.schriftgroesse));
-        b.setTranslateX(25);
-        b.setTranslateY(190);
-        b.setOnAction(e -> {
-            int order = Integer.parseInt(tf.getText()) - 1;
-            for (Bahnsteig ba : bt) {
-                ba.setOrderId(order);
-                alternativName = tname.getText();
-            }
-
-            stage.close();
-            Einstellungen.fenster.gleisbelegung.versteckeOrderIds();
-            Einstellungen.fenster.gleisbelegung.sortiereGleise();
-            Einstellungen.fenster.stellwerksuebersicht.aktualisiereBahnhofsNamen();
-        });
-
-        Pane p = new Pane(name, tname, l, tf, b);
-        p.setStyle("-fx-background-color: #303030;");
-        p.setMinSize(500, 200);
-        p.setMaxSize(500, 200);
-
-        Scene scene = new Scene(p, 300, 250);
-
-        stage.setScene(scene);
-        stage.show();
-        stage.setAlwaysOnTop(true);
-
-        stage.setOnCloseRequest(e -> {
-            Einstellungen.fenster.gleisbelegung.versteckeOrderIds();
-        });
-    }
-
-    @Override
-    public String toString() {
-        return "Bahnhof{" + "id=" + id + ", name='" + name + '\'' + ", bahnsteige=" + bahnsteige + '}';
-    }
-
-    public Vec2d getPos() {
-        return pos;
-    }
-
-    public void setPos(Vec2d pos) {
-        this.pos = pos;
-    }
-
-    public Collection<BahnhofVerbindung> getBahnhofVerbindungen() {
-        synchronized (bahnhofVerbindungen) {
-            return Collections.unmodifiableCollection(bahnhofVerbindungen.values());
-        }
-    }
-
-    public void addBahnhofVerbindung(Bahnhof bahnhof, double laenge, Line linie, Vec2d linienPos) {
-        BahnhofVerbindung verbindung = new BahnhofVerbindung(bahnhof, laenge, linie, linienPos);
-        synchronized (bahnhofVerbindungen) {
-            bahnhofVerbindungen.put(Integer.valueOf(bahnhof.id), verbindung);
-        }
-    }
-
-    public Line getLinie(Bahnhof bahnhof) {
-        BahnhofVerbindung bv = getVerbindung(bahnhof);
-
-        if (bv == null) {
-            return null;
-        }
-
-        return bv.linie;
-    }
-
-    public Set<Bahnhof> getVerbindungsBahnhoefe() {
-        Collection<BahnhofVerbindung> bvs = getBahnhofVerbindungen();
-        Set<Bahnhof> bahnhofSet = new HashSet<>();
-        for (BahnhofVerbindung bv : bvs) {
-            bahnhofSet.add(bv.getZielBahnhof());
-        }
-
-        return bahnhofSet;
-    }
-
-    public Vec2d getLinienPos(Bahnhof bahnhof) {
-        BahnhofVerbindung bv = getVerbindung(bahnhof);
-        if (bv == null) {
-            return null;
-        }
-
-        return bv.getLinienPos();
-    }
-
-    public boolean setLinienPos(Bahnhof bahnhof, Vec2d linienPos) {
-        BahnhofVerbindung bv = getVerbindung(bahnhof);
-        if (bv == null) {
-            return false;
-        }
-
-        bv.setLinienPos(linienPos);
-
-        return true;
-    }
-
-    public Bahnsteig getBahnsteigByName(String name) {
-        synchronized (bahnsteige) {
-            return bahnsteige.get(name);
-        }
-    }
-
-    public void addBahnsteig(Bahnsteig bahnsteig) {
-        synchronized (bahnsteige) {
-            this.bahnsteige.put(bahnsteig.getName(), bahnsteig);
-            this.lastBahnsteig = bahnsteig;
-        }
-        synchronized (bahnsteigListe) {
-            bahnsteigListe.add(bahnsteig);
-        }
-    }
-
-    public Bahnsteig getLastBahnsteig() {
-        synchronized (bahnsteige) {
-            return lastBahnsteig;
-        }
-    }
-
-    public void clearBahnhofVerbindungen() {
-        synchronized (bahnhofVerbindungen) {
-            this.bahnhofVerbindungen.clear();
-        }
+    public BahnhofTeil(LabelContainer bahnhofsLabel, List<Bahnsteig> bahnsteige) {
+      this.bahnhofsLabel = bahnhofsLabel;
+      this.bahnsteige = bahnsteige;
 
     }
 
-    public SortedMap<Integer, Bahnsteig> getBahnsteigOrderMap() {
-        SortedMap<Integer, Bahnsteig> bahnsteigMap = new TreeMap<>();
-        synchronized (bahnsteige) {
-            for (Bahnsteig bst : bahnsteige.values()) {
-                bahnsteigMap.put(Integer.valueOf(bst.getOrderId()), bst);
-            }
-        }
-
-        return bahnsteigMap;
+    void hervorheben() {
+      for (Bahnsteig b : bahnsteige) {
+        b.hebeHervor();
+      }
     }
 
-    public void clearBahnhofTeile() {
-        synchronized (bahnhofTeile) {
-            bahnhofTeile.clear();
-        }
-
+    public int getBahnsteigSize() {
+      return bahnsteige.size();
     }
+
+    public Iterator<Bahnsteig> iterator() {
+      return bahnsteige.iterator();
+    }
+  }
+
+  private int id;
+  private String name;
+  private String alternativName = "";
+  private Map<String, Bahnsteig> bahnsteige = new HashMap<>();
+  private List<Bahnsteig> bahnsteigListe = new ArrayList<>();
+  private List<BahnhofTeil> bahnhofTeile = new ArrayList<>();
+  private Map<Integer, BahnhofVerbindung> bahnhofVerbindungen = new HashMap<>();
+  private boolean sichtbar;
+  private Vec2d pos;
+  private Bahnsteig lastBahnsteig;
+
+  public Bahnhof(int id, String name) {
+    this.id = id;
+    this.name = name;
+    pos = new Vec2d(30, id * 40 + 40);
+  }
+
+  private BahnhofVerbindung getVerbindung(Bahnhof bahnhof) {
+    synchronized (bahnhofVerbindungen) {
+      return bahnhofVerbindungen.get(Integer.valueOf(bahnhof.id));
+    }
+  }
+
+  public int getId() {
+    return id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public Collection<Bahnsteig> getBahnsteige() {
+    synchronized (bahnsteigListe) {
+      return Collections.unmodifiableList(new ArrayList<>(bahnsteigListe));
+    }
+  }
+
+  public Bahnsteig getBahnsteig(int index) {
+    synchronized (bahnsteigListe) {
+      return bahnsteigListe.get(index);
+    }
+  }
+
+  public int getAnzahlBahnsteige() {
+    synchronized (bahnsteige) {
+      return bahnsteige.size();
+    }
+  }
+
+  public boolean isSichtbar() {
+    synchronized (bahnsteige) {
+      for (Bahnsteig b : bahnsteige.values()) {
+        if (!b.isSichtbar())
+          return false;
+
+      }
+    }
+    return true;
+  }
+
+  public void setSichtbar(boolean sichtbar) {
+    synchronized (bahnsteige) {
+      for (Bahnsteig b : bahnsteige.values())
+        b.setSichtbar(sichtbar);
+    }
+  }
+
+  public List<BahnhofTeil> getBahnhofTeile() {
+    synchronized (bahnhofTeile) {
+      return Collections.unmodifiableList(bahnhofTeile);
+    }
+  }
+
+  public void addBahnhofLabel(LabelContainer bahnhofLabel, List<Bahnsteig> bahnsteige) {
+    BahnhofTeil bt = new BahnhofTeil(bahnhofLabel, bahnsteige);
+    synchronized (bahnhofTeile) {
+      bahnhofTeile.add(bt);
+    }
+
+    bahnhofLabel.getLabel().setOnMouseClicked(e -> {
+      if (e.getButton() == MouseButton.PRIMARY) {
+        bt.hervorheben();
+        System.out.println(bt.getBahnsteigSize());
+      } else if (e.getButton() == MouseButton.SECONDARY) {
+        einstellungen(bt);
+      }
+    });
+  }
+
+  public String getAlternativName() {
+    return alternativName;
+  }
+
+  private void einstellungen(BahnhofTeil bt) {
+    Einstellungen.fenster.gleisbelegung.zeigeOrderIds();
+    Stage stage = new Stage();
+
+    Label name = new Label("Name:");
+    name.setStyle("-fx-text-fill: white;");
+    name.setFont(Font.font(Einstellungen.schriftgroesse));
+    name.setTranslateY(25);
+    name.setTranslateX(25);
+
+    TextField tname = new TextField(alternativName);
+    tname.setFont(Font.font(Einstellungen.schriftgroesse - 3));
+    tname.setTranslateX(25);
+    tname.setTranslateY(60);
+
+    Label l = new Label("Reihenfolge festlegen:");
+    l.setStyle("-fx-text-fill: white;");
+    l.setFont(Font.font(Einstellungen.schriftgroesse));
+    l.setTranslateX(25);
+    l.setTranslateY(95);
+
+    TextField tf = new TextField(String.valueOf(bahnsteige.get(0).getOrderId() + 1));
+    tf.setFont(Font.font(Einstellungen.schriftgroesse - 3));
+    tf.setTranslateX(25);
+    tf.setTranslateY(130);
+
+    Button b = new Button("Speichern");
+    b.setFont(Font.font(Einstellungen.schriftgroesse));
+    b.setTranslateX(25);
+    b.setTranslateY(190);
+    b.setOnAction(e -> {
+      int order = Integer.parseInt(tf.getText()) - 1;
+      for (Bahnsteig ba : bt) {
+        ba.setOrderId(order);
+        alternativName = tname.getText();
+      }
+
+      stage.close();
+      Einstellungen.fenster.gleisbelegung.versteckeOrderIds();
+      Einstellungen.fenster.gleisbelegung.sortiereGleise();
+      Einstellungen.fenster.stellwerksuebersicht.aktualisiereBahnhofsNamen();
+    });
+
+    Pane p = new Pane(name, tname, l, tf, b);
+    p.setStyle("-fx-background-color: #303030;");
+    p.setMinSize(500, 200);
+    p.setMaxSize(500, 200);
+
+    Scene scene = new Scene(p, 300, 250);
+
+    stage.setScene(scene);
+    stage.show();
+    stage.setAlwaysOnTop(true);
+
+    stage.setOnCloseRequest(e -> {
+      Einstellungen.fenster.gleisbelegung.versteckeOrderIds();
+    });
+  }
+
+  @Override
+  public String toString() {
+    return "Bahnhof{" + "id=" + id + ", name='" + name + '\'' + ", bahnsteige=" + bahnsteige + '}';
+  }
+
+  public Vec2d getPos() {
+    return pos;
+  }
+
+  public void setPos(Vec2d pos) {
+    this.pos = pos;
+  }
+
+  public Collection<BahnhofVerbindung> getBahnhofVerbindungen() {
+    synchronized (bahnhofVerbindungen) {
+      return Collections.unmodifiableCollection(bahnhofVerbindungen.values());
+    }
+  }
+
+  public void addBahnhofVerbindung(Bahnhof bahnhof, double laenge, Line linie, Vec2d linienPos) {
+    BahnhofVerbindung verbindung = new BahnhofVerbindung(bahnhof, laenge, linie, linienPos);
+    synchronized (bahnhofVerbindungen) {
+      bahnhofVerbindungen.put(Integer.valueOf(bahnhof.id), verbindung);
+    }
+  }
+
+  public Line getLinie(Bahnhof bahnhof) {
+    BahnhofVerbindung bv = getVerbindung(bahnhof);
+
+    if (bv == null) {
+      return null;
+    }
+
+    return bv.linie;
+  }
+
+  public Set<Bahnhof> getVerbindungsBahnhoefe() {
+    Collection<BahnhofVerbindung> bvs = getBahnhofVerbindungen();
+    Set<Bahnhof> bahnhofSet = new HashSet<>();
+    for (BahnhofVerbindung bv : bvs) {
+      bahnhofSet.add(bv.getZielBahnhof());
+    }
+
+    return bahnhofSet;
+  }
+
+  public Vec2d getLinienPos(Bahnhof bahnhof) {
+    BahnhofVerbindung bv = getVerbindung(bahnhof);
+    if (bv == null) {
+      return null;
+    }
+
+    return bv.getLinienPos();
+  }
+
+  public boolean setLinienPos(Bahnhof bahnhof, Vec2d linienPos) {
+    BahnhofVerbindung bv = getVerbindung(bahnhof);
+    if (bv == null) {
+      return false;
+    }
+
+    bv.setLinienPos(linienPos);
+
+    return true;
+  }
+
+  public Bahnsteig getBahnsteigByName(String name) {
+    synchronized (bahnsteige) {
+      return bahnsteige.get(name);
+    }
+  }
+
+  public void addBahnsteig(Bahnsteig bahnsteig) {
+    synchronized (bahnsteige) {
+      this.bahnsteige.put(bahnsteig.getName(), bahnsteig);
+      this.lastBahnsteig = bahnsteig;
+    }
+    synchronized (bahnsteigListe) {
+      bahnsteigListe.add(bahnsteig);
+    }
+  }
+
+  public Bahnsteig getLastBahnsteig() {
+    synchronized (bahnsteige) {
+      return lastBahnsteig;
+    }
+  }
+
+  public void clearBahnhofVerbindungen() {
+    synchronized (bahnhofVerbindungen) {
+      this.bahnhofVerbindungen.clear();
+    }
+
+  }
+
+  public SortedMap<Integer, Bahnsteig> getBahnsteigOrderMap() {
+    SortedMap<Integer, Bahnsteig> bahnsteigMap = new TreeMap<>();
+    synchronized (bahnsteige) {
+      for (Bahnsteig bst : bahnsteige.values()) {
+        bahnsteigMap.put(Integer.valueOf(bst.getOrderId()), bst);
+      }
+    }
+
+    return bahnsteigMap;
+  }
+
+  public void clearBahnhofTeile() {
+    synchronized (bahnhofTeile) {
+      bahnhofTeile.clear();
+    }
+
+  }
 }

--- a/Plugin Gleisbelegung/src/com/gleisbelegung/lib/data/Bahnhof.java
+++ b/Plugin Gleisbelegung/src/com/gleisbelegung/lib/data/Bahnhof.java
@@ -23,8 +23,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.SortedMap;
-import java.util.TreeMap;
+import java.util.SortedSet;
+import java.util.TreeSet;
 
 public class Bahnhof {
     /**
@@ -216,14 +216,48 @@ public class Bahnhof {
         b.setTranslateY(190);
         b.setOnAction(e -> {
             int order = Integer.parseInt(tf.getText()) - 1;
-            for (Bahnsteig ba : bt) {
-                ba.setOrderId(order);
-                alternativName = tname.getText();
+
+            List<Bahnsteig> newBahnsteigOrder = new ArrayList<>();
+            final SortedSet<Bahnsteig> bahnsteigeThis = new TreeSet<>();
+            Bahnhof.this.getBahnsteigOrderSet(bahnsteigeThis);
+            boolean nachZiel = false;
+            for (Bahnhof bhf : Einstellungen.fenster.getStellwerk().getBahnhoefe()) {
+                if (bhf == Bahnhof.this) {
+                  continue;
+                }
+                final SortedSet<Bahnsteig> set = new TreeSet<>();
+                bhf.getBahnsteigOrderSet(set);
+                Iterator<Bahnsteig> iter = set.iterator();
+                while (!nachZiel && iter.hasNext() && newBahnsteigOrder.size() < order) {
+                  newBahnsteigOrder.add(iter.next());
+                }
+                if (!nachZiel && newBahnsteigOrder.size() == order) {
+                  // Zielposition erreicht, alle Bahnsteige dieses Bahnhofs einsortiern
+                  for (Bahnsteig bst : bahnsteigeThis) {
+                    bst.setOrderId(order++);
+                    newBahnsteigOrder.add(bst);
+                  }
+                  nachZiel = true;
+                }
+                Bahnsteig bst = null;
+                while(iter.hasNext()) {
+                  bst = iter.next();
+                  if (nachZiel && bst.getOrderId() == order) {
+                    // fertig
+                    break;
+                  }
+                  bst.setOrderId(order++);
+                  newBahnsteigOrder.add(bst);
+                }
+                if (nachZiel && bst != null && bst.getOrderId() == order) {
+                  // fertig
+                  break;
+                }
             }
 
             stage.close();
             Einstellungen.fenster.gleisbelegung.versteckeOrderIds();
-            Einstellungen.fenster.gleisbelegung.sortiereGleise();
+            Einstellungen.fenster.gleisbelegung.sortiereGleise(null);
             Einstellungen.fenster.stellwerksuebersicht.aktualisiereBahnhofsNamen();
         });
 
@@ -338,15 +372,10 @@ public class Bahnhof {
 
     }
 
-    public SortedMap<Integer, Bahnsteig> getBahnsteigOrderMap() {
-        SortedMap<Integer, Bahnsteig> bahnsteigMap = new TreeMap<>();
+    public void getBahnsteigOrderSet(Set<Bahnsteig> set) {
         synchronized (bahnsteige) {
-            for (Bahnsteig bst : bahnsteige.values()) {
-                bahnsteigMap.put(Integer.valueOf(bst.getOrderId()), bst);
-            }
+          set.addAll(bahnsteige.values());
         }
-
-        return bahnsteigMap;
     }
 
     public void clearBahnhofTeile() {

--- a/Plugin Gleisbelegung/src/com/gleisbelegung/lib/data/Bahnsteig.java
+++ b/Plugin Gleisbelegung/src/com/gleisbelegung/lib/data/Bahnsteig.java
@@ -18,7 +18,6 @@ import javafx.stage.Stage;
 import java.util.ArrayList;
 
 public class Bahnsteig extends Plugin {
-    private ArrayList<LabelContainer> spalte;
     private LabelContainer gleisLabel;
     private String name;
     private BooleanProperty sichtbar;
@@ -34,15 +33,7 @@ public class Bahnsteig extends Plugin {
         this.orderId = orderId;
         id = orderId;
 
-        spalte = new ArrayList<>();
         hervorgehoben = false;
-    }
-
-    public ArrayList<LabelContainer> getSpalte() {
-        return spalte;
-    }
-    public void setSpalte(ArrayList<LabelContainer> spalte) {
-        this.spalte = spalte;
     }
 
     public String getName() {
@@ -79,7 +70,7 @@ public class Bahnsteig extends Plugin {
     }
 
     public void setLabelContainerToWith(int width){
-        for(LabelContainer lc : spalte){
+        /*for(LabelContainer lc : spalte){
             Platform.runLater(() -> {
                 lc.getLabel().setMaxWidth(width);
                 lc.getLabel().setPrefWidth(width);
@@ -91,11 +82,11 @@ public class Bahnsteig extends Plugin {
             gleisLabel.getLabel().setMaxWidth(width);
             gleisLabel.getLabel().setPrefWidth(width);
             gleisLabel.getLabel().setMinWidth(width);
-        });
+        });*/
     }
 
     public void hebeHervor(){
-        if(hervorgehoben) {
+        /*if(hervorgehoben) {
             gleisLabel.getLabel().setStyle(gleisLabel.getLabel().getStyle() + "; -fx-background-color: #303030");
             for(LabelContainer lc : spalte){
                 lc.setHervorhebungDurchGleis(false);
@@ -110,7 +101,7 @@ public class Bahnsteig extends Plugin {
             }
 
             hervorgehoben = true;
-        }
+        }*/
     }
     public boolean getHebeHervor(){
         return hervorgehoben;
@@ -177,7 +168,6 @@ public class Bahnsteig extends Plugin {
     @Override
     public String toString() {
         return "Bahnsteig{" +
-                "spalte=" + spalte +
                 ", gleisLabel=" + gleisLabel +
                 ", gleisName='" + name + '\'' +
                 ", sichtbar=" + sichtbar +

--- a/Plugin Gleisbelegung/src/com/gleisbelegung/lib/data/Bahnsteig.java
+++ b/Plugin Gleisbelegung/src/com/gleisbelegung/lib/data/Bahnsteig.java
@@ -16,8 +16,10 @@ import javafx.scene.text.Font;
 import javafx.stage.Stage;
 
 import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.SortedSet;
 
-public class Bahnsteig extends Plugin {
+public class Bahnsteig extends Plugin implements Comparable<Bahnsteig> {
     private LabelContainer gleisLabel;
     private String name;
     private BooleanProperty sichtbar;
@@ -25,6 +27,7 @@ public class Bahnsteig extends Plugin {
     private int orderId;
     private int id;
     private Bahnhof bahnhof;
+    private boolean sorting = false;
 
     public Bahnsteig(Bahnhof b, String name, int orderId){
         this.bahnhof = b;
@@ -122,6 +125,36 @@ public class Bahnsteig extends Plugin {
         return bahnhof;
     }
 
+    // Sorting active on this bahnsteig
+    void setSortActive() {
+      this.sorting = true;
+    }
+
+    void resetSortActive() {
+      this.sorting = false;
+    }
+
+    @Override
+    public int compareTo(final Bahnsteig o) {
+        if (this == o) {
+          return 0;
+        }
+        int cmp;
+        cmp = this.getOrderId() - o.getOrderId();
+        if (cmp != 0) {
+          return cmp;
+        }
+
+        // code should never apply below
+        cmp = this.getId() - this.getOrderId();
+        if (cmp != 0) {
+          return cmp;
+        }
+        cmp = o.getOrderId() - o.getId();
+        return cmp;
+      }
+
+
     private void aendereReihenfolge(){
         Einstellungen.fenster.gleisbelegung.zeigeOrderIds();
 
@@ -143,10 +176,15 @@ public class Bahnsteig extends Plugin {
         b.setTranslateX(25);
         b.setTranslateY(120);
         b.setOnAction(e -> {
-            orderId = Integer.parseInt(tf.getText())-1;
+            Bahnsteig.this.setOrderId(Integer.parseInt(tf.getText()) - 1);
+            Bahnsteig.this.setSortActive();
             stage.close();
             Einstellungen.fenster.gleisbelegung.versteckeOrderIds();
-            Einstellungen.fenster.gleisbelegung.sortiereGleise();
+            Einstellungen.fenster.gleisbelegung.sortiereGleise(new Runnable() {
+              public void run() {
+                Bahnsteig.this.resetSortActive();
+              }
+            });
         });
 
         Pane p = new Pane(l,tf,b);
@@ -176,4 +214,15 @@ public class Bahnsteig extends Plugin {
                 ", id=" + id +
                 '}';
     }
+
+  public boolean getSortingActive() {
+    return this.sorting;
+  }
+
+  public static void applySorting(SortedSet<Bahnsteig> bahnsteige) {
+      for(Bahnsteig bahnsteig : bahnsteige) {
+        bahnsteig.setSortActive();
+        bahnsteig.aendereReihenfolge();
+      }
+  }
 }

--- a/Plugin Gleisbelegung/src/com/gleisbelegung/lib/data/FahrplanHalt.java
+++ b/Plugin Gleisbelegung/src/com/gleisbelegung/lib/data/FahrplanHalt.java
@@ -24,6 +24,8 @@ public class FahrplanHalt {
     private FahrplanHalt vorgaenger;                          //Hat der Zug einen vorgaenger, wenn ja, dann hier der Flügelt- oder Wechselhalt gespeichert
     private Zug flaggedTrain;                       //Hat der Zug einen nachfolger, wenn ja, dann hier gespeichert, wenn nein dann null
     private boolean needUpdate;
+    private static long idCounter = 0;
+    private long id;
 
     //Speichert gegebene Seite
     public FahrplanHalt(long abfahrt, Bahnsteig gleis, String flags, Bahnsteig plangleis, long ankuft, Zug z){
@@ -41,7 +43,8 @@ public class FahrplanHalt {
         crossing = flags.contains("D") || flags.equals("D");
         needUpdate = true;
 
-        //TODO isNeedUpdate in Fahrplanhalt auslagern
+        id = idCounter;
+        idCounter++;
     }
 
     //get zug
@@ -185,5 +188,13 @@ public class FahrplanHalt {
                 ", crossing=" + crossing +
                 ", flaggedTrain=" + flaggedTrain +
                 '}';
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
     }
 }

--- a/Plugin Gleisbelegung/src/com/gleisbelegung/lib/data/FahrplanHalt.java
+++ b/Plugin Gleisbelegung/src/com/gleisbelegung/lib/data/FahrplanHalt.java
@@ -56,7 +56,10 @@ public class FahrplanHalt {
     public long getAnkuft() {
         return ankuft;
     }
-    public long getTatsaechlicheAnkunf(){
+    public long getTatsaechlicheAnkunft(){
+        if(ankuft == 0 && vorgaenger != null){
+            return vorgaenger.getTatsaechlicheAnkunft();
+        }
         return  ankuft;
     }
     public void setAnkuft(long ankuft) {
@@ -68,7 +71,10 @@ public class FahrplanHalt {
         return abfahrt;
     }
     public long getTatsaechlicheAbfahrt(){
-        return  abfahrt;
+        if(abfahrt == 0 && flaggedTrain != null){
+            return flaggedTrain.getFahrplan(0).getTatsaechlicheAbfahrt();
+        }
+        return abfahrt;
     }
     public void setAbfahrt(long abfahrt) {
         this.abfahrt = abfahrt;

--- a/Plugin Gleisbelegung/src/com/gleisbelegung/lib/data/FahrplanHalt.java
+++ b/Plugin Gleisbelegung/src/com/gleisbelegung/lib/data/FahrplanHalt.java
@@ -23,6 +23,7 @@ public class FahrplanHalt {
     private boolean crossing;                       //Hat der Zug hier eine Durchfahrt
     private FahrplanHalt vorgaenger;                          //Hat der Zug einen vorgaenger, wenn ja, dann hier der Flügelt- oder Wechselhalt gespeichert
     private Zug flaggedTrain;                       //Hat der Zug einen nachfolger, wenn ja, dann hier gespeichert, wenn nein dann null
+    private boolean needUpdate;
 
     //Speichert gegebene Seite
     public FahrplanHalt(long abfahrt, Bahnsteig gleis, String flags, Bahnsteig plangleis, long ankuft, Zug z){
@@ -38,16 +39,22 @@ public class FahrplanHalt {
         flaggedTrain = null;
 
         crossing = flags.contains("D") || flags.equals("D");
+        needUpdate = true;
+
+        //TODO isNeedUpdate in Fahrplanhalt auslagern
     }
 
     //get zug
-    public Zug getZ() {
+    public Zug getZug() {
         return z;
     }
 
     //get-set Ankunft
     public long getAnkuft() {
         return ankuft;
+    }
+    public long getTatsaechlicheAnkunf(){
+        return  ankuft;
     }
     public void setAnkuft(long ankuft) {
         this.ankuft = ankuft;
@@ -56,6 +63,9 @@ public class FahrplanHalt {
     //get-set Abfahrt
     public long getAbfahrt() {
         return abfahrt;
+    }
+    public long getTatsaechlicheAbfahrt(){
+        return  abfahrt;
     }
     public void setAbfahrt(long abfahrt) {
         this.abfahrt = abfahrt;
@@ -153,6 +163,13 @@ public class FahrplanHalt {
 
     public void setVorgaenger(FahrplanHalt vorgaenger) {
         this.vorgaenger = vorgaenger;
+    }
+
+    public boolean isNeedUpdate() {
+        return needUpdate;
+    }
+    public void setNeedUpdate(boolean needUpdate) {
+        this.needUpdate = needUpdate;
     }
 
     @Override

--- a/Plugin Gleisbelegung/src/com/gleisbelegung/lib/data/Zug.java
+++ b/Plugin Gleisbelegung/src/com/gleisbelegung/lib/data/Zug.java
@@ -29,6 +29,7 @@ public class Zug {
     private List<FahrplanHalt> fahrplan;    //Speichert alle Fahrplanhalt des Zuges aus der @FahrplanHalt-Klasse
     private boolean newTrain;           //Wenn ein Zug gerade neu in die Liste zuege aus @Main aufgenommen wurde ist dieser Wert auf true
     private Label stellwerksUebersichtLabel;
+    private boolean schwerwiegendesUpdate;
 
     //Setzten der Daten
     public Zug(int zugId, String zugName){
@@ -42,6 +43,7 @@ public class Zug {
         stellwerksUebersichtLabel = new Label(zugName);
         stellwerksUebersichtLabel.setStyle("-fx-text-fill: #fff;");
         stellwerksUebersichtLabel.setFont(Font.font(Einstellungen.schriftgroesse));
+        schwerwiegendesUpdate = false;
     }
 
     //get-set Zugname
@@ -191,8 +193,16 @@ public class Zug {
     }
 
     public void setNeedUpdate(boolean value){
+        schwerwiegendesUpdate = true;
         for(FahrplanHalt fh : fahrplan){
             fh.setNeedUpdate(value);
         }
+    }
+
+    public boolean isSchwerwiegendesUpdate() {
+        return schwerwiegendesUpdate;
+    }
+    public void setSchwerwiegendesUpdate(boolean schwerwiegendesUpdate) {
+        this.schwerwiegendesUpdate = schwerwiegendesUpdate;
     }
 }

--- a/Plugin Gleisbelegung/src/com/gleisbelegung/lib/data/Zug.java
+++ b/Plugin Gleisbelegung/src/com/gleisbelegung/lib/data/Zug.java
@@ -14,6 +14,7 @@ import javafx.scene.control.Label;
 import javafx.scene.text.Font;
 
 import java.util.ArrayList;
+import java.util.List;
 
 public class Zug {
     private int zugId;                  //einmalige Zugidentifikationsnummer
@@ -25,8 +26,7 @@ public class Zug {
     private String von;                 //Einfahrt des Zuges in das Stellwerk
     private String nach;                //Ausfahrt des Zuges aus dem Stellwerk
     private boolean sichtbar;           //Ist der Zug aktuell im Stellwerksichbar
-    private ArrayList<FahrplanHalt> fahrplan;    //Speichert alle Fahrplanhalt des Zuges aus der @FahrplanHalt-Klasse
-    private boolean needUpdate;         //Wenn der Zug ein Update benötigt, dann wird er in @Fenster.drawTrain() neu gezeichnet
+    private List<FahrplanHalt> fahrplan;    //Speichert alle Fahrplanhalt des Zuges aus der @FahrplanHalt-Klasse
     private boolean newTrain;           //Wenn ein Zug gerade neu in die Liste zuege aus @Main aufgenommen wurde ist dieser Wert auf true
     private Label stellwerksUebersichtLabel;
 
@@ -36,7 +36,8 @@ public class Zug {
         this.zugName = zugName;
 
         this.newTrain = true;
-        this.needUpdate = true;
+
+        fahrplan = new ArrayList<FahrplanHalt>();
 
         stellwerksUebersichtLabel = new Label(zugName);
         stellwerksUebersichtLabel.setStyle("-fx-text-fill: #fff;");
@@ -60,8 +61,11 @@ public class Zug {
     }
 
     //get-set Verspätung
-    public int getVerspaetung() {
+    public int getVerspaetungInMinuten() {
         return verspaetung;
+    }
+    public long getVerspaetungInMiliSekunden(){
+        return  verspaetung*1000*60;
     }
     public void setVerspaetung(int verspaetung) {
         this.verspaetung = verspaetung;
@@ -116,7 +120,7 @@ public class Zug {
     }
 
     //get-set FahrplanHalt
-    public ArrayList<FahrplanHalt> getFahrplan() {
+    public List<FahrplanHalt> getFahrplan() {
         return fahrplan;
     }
     public FahrplanHalt getFahrplan(int index) {
@@ -128,14 +132,6 @@ public class Zug {
     }
     public void setFahrplan(ArrayList<FahrplanHalt> fahrplan) {
         this.fahrplan = fahrplan;
-    }
-
-    //get-set needUpdate
-    public boolean isNeedUpdate() {
-        return needUpdate;
-    }
-    public void setNeedUpdate(boolean needsUpdate) {
-        this.needUpdate = needsUpdate;
     }
 
     //get-set newTrain
@@ -182,7 +178,6 @@ public class Zug {
                 ", von='" + von + '\'' +
                 ", nach='" + nach + '\'' +
                 ", sichtbar=" + sichtbar +
-                ", needUpdate=" + needUpdate +
                 ", newTrain=" + newTrain +
                 '}';
     }
@@ -193,5 +188,11 @@ public class Zug {
 
     public void setStellwerksUebersichtLabel(Label stellwerksUebersichtLabel) {
         this.stellwerksUebersichtLabel = stellwerksUebersichtLabel;
+    }
+
+    public void setNeedUpdate(boolean value){
+        for(FahrplanHalt fh : fahrplan){
+            fh.setNeedUpdate(value);
+        }
     }
 }


### PR DESCRIPTION
Umbau Code zur Behebung von #108.

@manuel3108 Es ist hilfreich alle Variablen auf private zu setzen, so kann man den Zugriff besser kontrollieren. Alles von überall erreichbar (public) zu haben, ist schlecht wartbar und daher schlechter Programmierstil.

`removeFahrplanhalt()` ist noch nicht thread-sicher (kann damit Opfer der ConcurrentModificationException werden). Die Logik scheint mir zu kompliziert zu sein, du willst in 3-fach verschachtelten Schleifen ermitteln, ob der Fahrplanhalt im Fahrplan eines Zuges vorkommt.

`entferneVergangenheit()` lässt sich mit Iterator-Klasse deutlich eleganter schreiben, ich mach dafür einen eigenen PR auf. Mit neueren Java-Versionen (8+) sogar ohne Schleife. #110